### PR TITLE
Build Nix-shell store-paths before cachix push

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ jobs:
           name: Push Cachix
           command: |
             # Instantiate nix-shell and push closure to project cache
+            nix-shell --pure --run :
             nix-store -qR --include-outputs $(nix-instantiate shell.nix) | cachix push capabilities-via
       - run:
           name: Build library


### PR DESCRIPTION
In https://github.com/tweag/capabilities-via/pull/29#discussion_r215155685 I overlooked that `nix-instantiate` only generates the derivation, but does not actually build it and generate the store path. This can be observed on CI, where the "Push Cachix" step will not actually build anything, but the "Build library" step will build all the dependencies (or fetch them from cache).