### PR TITLE
Remove other-extensions field

### DIFF
--- a/capabilities-via.cabal
+++ b/capabilities-via.cabal
@@ -23,29 +23,6 @@ library
     HasStream
     HasWriter
     HasWriter.Discouraged
-  other-extensions:
-    AllowAmbiguousTypes
-    BangPatterns
-    DataKinds
-    DeriveGeneric
-    DerivingVia
-    FlexibleContexts
-    FlexibleInstances
-    FunctionalDependencies
-    GeneralizedNewtypeDeriving
-    InstanceSigs
-    KindSignatures
-    MagicHash
-    MultiParamTypeClasses
-    QuantifiedConstraints
-    RankNTypes
-    ScopedTypeVariables
-    StandaloneDeriving
-    TypeApplications
-    TypeFamilies
-    TypeInType
-    UnboxedTuples
-    UndecidableInstances
   build-depends:
       base >=4.10 && <4.13
     , exceptions


### PR DESCRIPTION
It's a bore to maintain and since it's not auto-generated, its content
is bound to become false over time.