### PR TITLE
Remove other-extensions

### DIFF
--- a/capabilities-via.cabal
+++ b/capabilities-via.cabal
@@ -24,29 +24,6 @@ library
     HasStream
     HasWriter
     HasWriter.Discouraged
-  other-extensions:
-    AllowAmbiguousTypes
-    BangPatterns
-    DataKinds
-    DeriveGeneric
-    DerivingVia
-    FlexibleContexts
-    FlexibleInstances
-    FunctionalDependencies
-    GeneralizedNewtypeDeriving
-    InstanceSigs
-    KindSignatures
-    MagicHash
-    MultiParamTypeClasses
-    QuantifiedConstraints
-    RankNTypes
-    ScopedTypeVariables
-    StandaloneDeriving
-    TypeApplications
-    TypeFamilies
-    TypeInType
-    UnboxedTuples
-    UndecidableInstances
   build-depends:
       base >=4.10 && <4.13
     , exceptions


### PR DESCRIPTION
There is no static check available that ensures that this field is
up-to-date. This means it is very likely for this information to become
outdated. No information is better than false information. Hence, the
field is removed.