### PR TITLE
Fix missing a -XOverloadedStrings in readme examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Execute the following commands to try it out:
 $ nix-shell --pure --run "cabal configure --enable-tests"
 $ nix-shell --pure --run "cabal repl examples"
 
+ghci> :set -XOverloadedStrings
 ghci> wordAndLetterCount "ab ba"
 Letters
 'a': 2


### PR DESCRIPTION
Rational: the readme instructions supposes that `-XOverloadedStrings` is turned on, which is not the default and leads to error `Couldn't match expected type ‘Text’ with actual type ‘[Char]’`.

This fix specify this information on the README, so user may not be confused with the error.