### PR TITLE
Extend README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,14 @@ Compared to the widely used [`mtl`][mtl] the capability type classes provided
 by this library are not tied to a particular implementation.
 Instead this library provides newtype wrappers that define extensible strategies
 to derive capability instances in deriving-via clauses
-using the `DerivingVia` language extension introduced in GHC 8.6.
+using the [`DerivingVia`][deriving-via] language extension
+introduced in GHC 8.6.
 
 In short, an example usage looks like this:
 
 ``` haskell
-example :: (HasReader "foo" Int, HasState "bar" Bool) => m ()
-example = do
+testParity :: (HasReader "foo" Int, HasState "bar" Bool) => m ()
+testParity = do
   num <- ask @"foo"
   put @"bar" (even num)
 
@@ -29,10 +30,22 @@ data Ctx = Ctx { foo :: Int, bar :: IORef Bool }
 
 newtype M a = M { runM :: Ctx -> IO a }
   deriving (Functor, Applicative, Monad) via ReaderT Ctx IO
+  -- Use DerivingVia to derive a HasReader instance.
   deriving (HasReader "foo" Int) via
+    -- Pick the field foo from the Ctx record in the ReaderT environment.
     Field "foo" "ctx" (MonadReader (ReaderT Ctx IO))
+  -- Use DerivingVia to derive a HasState instance.
   deriving (HasState "bar" Bool) via
+    -- Convert a reader of IORef to a state capability.
     ReaderIORef (Field "bar" "ctx" (MonadReader (ReaderT Ctx IO)))
+
+example :: IO ()
+example = do
+    rEven <- newIORef False
+    runM testParity (Ctx 2 rEven)
+    readIORef rEven >>= print
+    runM testParity (Ctx 3 rEven)
+    readIORef rEven >>= print
 ```
 
 Refer to the [Examples section](#examples)
@@ -50,6 +63,7 @@ on the artifacts tab of a successful build.
 [circleci]: https://circleci.com/gh/tweag/capabilities-via/tree/master
 [mtl]: http://hackage.haskell.org/package/mtl
 [blog]: https://www.tweag.io/posts/2018-09-27-capability.html
+[deriving-via]: https://downloads.haskell.org/~ghc/8.6.1/docs/html/users_guide/glasgow_exts.html#deriving-via
 
 ## Nix Shell
 


### PR DESCRIPTION
- Show example before build instructions
- Add two paragraphs introducing the library