### PR TITLE
Expand Accessor documentation.

### DIFF
--- a/src/Capability/Accessors.hs
+++ b/src/Capability/Accessors.hs
@@ -33,8 +33,10 @@ import GHC.TypeLits (Nat, Symbol)
 --     Coerce MyInt (MonadReader (Reader Int))
 -- @
 --
--- Converts the @HasReader \"a\" Int@ instance of @MonadReader (Reader Int)@
--- to a @HasReader \"a\" MyInt@ instance using @Coercible Int MyInt@.
+-- Converts the @'Capability.Reader.HasReader' \"a\" Int@ instance of
+-- @'Capability.Reader.MonadReader' (Reader Int)@ to a
+-- @'Capability.Reader.HasReader' \"a\" MyInt@
+-- instance using @Coercible Int MyInt@.
 newtype Coerce (to :: *) m (a :: *) = Coerce (m a)
   deriving (Functor, Applicative, Monad, MonadIO, PrimMonad)
 
@@ -48,11 +50,11 @@ newtype Coerce (to :: *) m (a :: *) = Coerce (m a)
 --     Rename "bar" (MonadReader (Reader Int))
 -- @
 --
--- Converts the @HasReader \"bar\" Int@ instance of
--- @MonadReader (Reader Int)@ to a
--- @HasReader \"foo\" Int@ instance by renaming the tag.
+-- Converts the @'Capability.Reader.HasReader' \"bar\" Int@ instance of
+-- @'Capability.Reader.MonadReader' (Reader Int)@ to a
+-- @'Capability.Reader.HasReader' \"foo\" Int@ instance by renaming the tag.
 --
--- Note, that @MonadReader@ itself does not fix a tag,
+-- Note, that 'Capability.Reader.MonadReader' itself does not fix a tag,
 -- and @Rename@ is redundant in this example.
 --
 -- See 'Pos' below for a common use-case.
@@ -70,9 +72,10 @@ newtype Rename (oldtag :: k) m (a :: *) = Rename (m a)
 --     Field "foo" () (MonadReader (Reader Foo))
 -- @
 --
--- Converts the @HasReader () Foo@ instance of @MonadReader (Reader Foo)@ to a
--- @HasReader \"foo\" Int@ instance by focusing on the field @foo@ in
--- the @Foo@ record.
+-- Converts the @'Capability.Reader.HasReader' () Foo@ instance of
+-- @'Capability.Reader.MonadReader' (Reader Foo)@ to a
+-- @'Capability.Reader.HasReader' \"foo\" Int@
+-- instance by focusing on the field @foo@ in the @Foo@ record.
 --
 -- See 'Rename' for a way to change the tag.
 newtype Field (field :: Symbol) (oldtag :: k) m (a :: *) = Field (m a)
@@ -88,8 +91,9 @@ newtype Field (field :: Symbol) (oldtag :: k) m (a :: *) = Field (m a)
 --     Pos 1 () (MonadReader (Reader (Int, Bool)))
 -- @
 --
--- Converts the @HasReader () (Int, Bool)@ instance of
--- @MonadReader (Reader (Int, Bool))@ to a @HasReader 1 Int@ instance
+-- Converts the @'Capability.Reader.HasReader' () (Int, Bool)@ instance of
+-- @'Capability.Reader.MonadReader' (Reader (Int, Bool))@ to a
+-- @'Capability.Reader.HasReader' 1 Int@ instance
 -- by focusing on the first element of the tuple.
 --
 -- The implied number tag can be renamed to a more descriptive name using
@@ -114,10 +118,10 @@ newtype Pos (pos :: Nat) (oldtag :: k) m (a :: *) = Pos (m a)
 --     Ctor \"ErrB" () (MonadError (ExceptT MyError Identity))
 -- @
 --
--- Converts the @HasThrow () \"MyError\"@ instance of
--- @MonadError (ExceptT MyError Identity)@ to a
--- @HasThrow \"ErrB\" String@ instance by wrapping thrown @String@s
--- in the @ErrB@ constructor.
+-- Converts the @'Capability.Error.HasThrow' () \"MyError\"@ instance of
+-- @'Capability.Error.MonadError' (ExceptT MyError Identity)@ to a
+-- @'Capability.Error.HasThrow' \"ErrB\" String@
+-- instance by wrapping thrown @String@s in the @ErrB@ constructor.
 newtype Ctor (ctor :: Symbol) (oldtag :: k) m (a :: *) = Ctor (m a)
   deriving (Functor, Applicative, Monad, MonadIO, PrimMonad)
 
@@ -134,9 +138,11 @@ newtype Ctor (ctor :: Symbol) (oldtag :: k) m (a :: *) = Ctor (m a)
 --     Lift (StateT Int (MonadState (State Bool)))
 -- @
 --
--- Uses the @MonadTrans@ instance of @StateT Int@ to lift
--- the @HasState "\foo\" Bool@ instance of the underlying
--- @MonadState (State Bool)@ over the @StateT Int@ monad transformer.
+-- Uses the 'Control.Monad.Trans.Class.MonadTrans' instance of
+-- @StateT Int@ to lift
+-- the @'Capability.State.HasState' "\foo\" Bool@ instance of the underlying
+-- @'Capability.State.MonadState' (State Bool)@ over the
+-- @StateT Int@ monad transformer.
 newtype Lift m (a :: *) = Lift (m a)
   deriving (Functor, Applicative, Monad, MonadIO, PrimMonad)
 


### PR DESCRIPTION
- Explain effect of the applied accessor in the corresponding example.
- Motivate the presence of `Pos` in the `Rename` example.