### PR TITLE
Add support for building with Stack.

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,6 @@
+resolver: nightly-2018-09-29
+packages:
+- '.'
+extra-deps:
+- git: https://github.com/LeastAuthority/hspec-jenkins.git
+  commit: 2899766bbd36216b81b1719423a5c2443458ae06


### PR DESCRIPTION
This uses nightly 2018-09-29, which has switched to GHC-8.6.1. No
extra-deps required for build. One extra-dep required for test due to
an unreleased test dependency.