### PR TITLE
Rename internal Instances modules to Strategies.

### DIFF
--- a/capability.cabal
+++ b/capability.cabal
@@ -17,10 +17,10 @@ library
     Capability.Error
     Capability.Reader
     Capability.Reader.Internal.Class
-    Capability.Reader.Internal.Instances
+    Capability.Reader.Internal.Strategies
     Capability.State
     Capability.State.Internal.Class
-    Capability.State.Internal.Instances
+    Capability.State.Internal.Strategies
     Capability.Stream
     Capability.Writer
     Capability.Writer.Discouraged

--- a/src/Capability/Reader.hs
+++ b/src/Capability/Reader.hs
@@ -22,4 +22,4 @@ module Capability.Reader
 
 import Capability.Accessors
 import Capability.Reader.Internal.Class
-import Capability.Reader.Internal.Instances
+import Capability.Reader.Internal.Strategies

--- a/src/Capability/Reader/Internal/Strategies.hs
+++ b/src/Capability/Reader/Internal/Strategies.hs
@@ -19,7 +19,7 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 {-# OPTIONS_GHC -Wno-simplifiable-class-constraints #-}
 
-module Capability.Reader.Internal.Instances
+module Capability.Reader.Internal.Strategies
   ( MonadReader(..)
   , ReadStatePure(..)
   , ReadState(..)

--- a/src/Capability/State.hs
+++ b/src/Capability/State.hs
@@ -28,4 +28,4 @@ module Capability.State
 
 import Capability.Accessors
 import Capability.State.Internal.Class
-import Capability.State.Internal.Instances
+import Capability.State.Internal.Strategies

--- a/src/Capability/State/Internal/Strategies.hs
+++ b/src/Capability/State/Internal/Strategies.hs
@@ -19,7 +19,7 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 {-# OPTIONS_GHC -Wno-simplifiable-class-constraints #-}
 
-module Capability.State.Internal.Instances
+module Capability.State.Internal.Strategies
   ( MonadState(..)
   , ReaderIORef(..)
   , ReaderRef(..)


### PR DESCRIPTION
By convention, `*.Instances` modules do not export anything, and just
bring instances into scope. That's not the meaning we're using, so we
should change the module names to something else.