### PR TITLE
Update nixpkgs revision

### DIFF
--- a/nix/haskell/default.nix
+++ b/nix/haskell/default.nix
@@ -15,11 +15,8 @@ self: super:
           # generic-lens's inspection-testing test-suite fails.
           generic-lens = super.haskell.lib.dontCheck hssuper.generic-lens;
 
-          contravariant = super.haskell.lib.doJailbreak hssuper.contravariant;
-          doctest = super.haskell.lib.doJailbreak hssuper.doctest;
           free = super.haskell.lib.doJailbreak hssuper.free;
-          safe-exceptions = super.haskell.lib.doJailbreak hssuper.safe-exceptions;
-          unliftio-core = super.haskell.lib.doJailbreak hssuper.unliftio-core;
+          lens = super.haskell.lib.doJailbreak hssuper.lens;
 
           hspec-jenkins = super.haskell.lib.appendPatch hssuper.hspec-jenkins
             (super.fetchpatch {
@@ -29,45 +26,6 @@ self: super:
             })
           ;
 
-          adjunctions = super.haskell.lib.overrideCabal hssuper.adjunctions (attrs: {
-            postPatch = ''
-              ${attrs.postPatch or ""}
-              sed -i '
-                /import Data\.Functor\.Contravariant$/s/import/import "contravariant"/;
-                1i{-# LANGUAGE PackageImports #-}' \
-                src/Control/Monad/Trans/Contravariant/Adjoint.hs \
-                src/Data/Functor/Contravariant/Adjunction.hs \
-                src/Data/Functor/Contravariant/Rep.hs
-            '';
-          });
-          foldl = super.haskell.lib.overrideCabal hssuper.foldl (attrs: {
-            jailbreak = true;
-            postPatch = ''
-              ${attrs.postPatch or ""}
-              sed -i '
-                /import Data\.Functor\.Contravariant/s/import/import "contravariant"/;
-                1i{-# LANGUAGE PackageImports #-}' \
-                src/Control/Foldl.hs
-            '';
-          });
-          haskell-src-exts = super.haskell.lib.overrideCabal hssuper.haskell-src-exts (attrs: {
-            jailbreak = true;
-            postPatch = ''
-              ${attrs.postPatch or ""}
-              sed -i '
-                1i{-# LANGUAGE NoMonadFailDesugaring #-}' \
-                src/Language/Haskell/Exts/InternalLexer.hs \
-                src/Language/Haskell/Exts/ParseUtils.hs
-            '';
-          });
-          hspec-core = super.haskell.lib.overrideCabal hssuper.hspec-core (attrs: {
-            postPatch = ''
-              ${attrs.postPatch or ""}
-              sed -i '
-                1i{-# LANGUAGE NoMonadFailDesugaring #-}' \
-                test/Test/Hspec/Core/Example/LocationSpec.hs
-            '';
-          });
           inspection-testing = super.haskell.lib.overrideCabal hssuper.inspection-testing (attrs: {
             jailbreak = true;
             postPatch = ''
@@ -75,56 +33,6 @@ self: super:
               sed -i '
                 1i{-# LANGUAGE NoMonadFailDesugaring #-}' \
                 Test/Inspection/Plugin.hs
-            '';
-          });
-          invariant = super.haskell.lib.overrideCabal hssuper.invariant (attrs: {
-            postPatch = ''
-              ${attrs.postPatch or ""}
-              sed -i '
-                /import\s\+Data\.Functor\.Contravariant/s/import/import "contravariant"/;
-                1i{-# LANGUAGE PackageImports #-}' \
-                src/Data/Functor/Invariant.hs
-            '';
-          });
-          kan-extensions = super.haskell.lib.overrideCabal hssuper.kan-extensions (attrs: {
-            postPatch = ''
-              ${attrs.postPatch or ""}
-              sed -i '
-                /import Data\.Functor\.Contravariant$/s/import/import "contravariant"/;
-                1i{-# LANGUAGE PackageImports #-}' \
-                src/Data/Functor/Contravariant/Coyoneda.hs \
-                src/Data/Functor/Contravariant/Day.hs \
-                src/Data/Functor/Contravariant/Yoneda.hs
-            '';
-          });
-          lens = super.haskell.lib.overrideCabal hssuper.lens (attrs: {
-            jailbreak = true;
-            postPatch = ''
-              ${attrs.postPatch or ""}
-              sed -i '
-                /import\s\+Data\.Functor\.Contravariant/s/import/import "contravariant"/;
-                1i{-# LANGUAGE PackageImports #-}' \
-                $(grep -Rl "import\s\+Data\.Functor\.Contravariant$")
-            '';
-          });
-          polyparse = super.haskell.lib.overrideCabal hssuper.polyparse (attrs: {
-            jailbreak = true;
-            postPatch = ''
-              ${attrs.postPatch or ""}
-              sed -i '
-                1i{-# LANGUAGE NoMonadFailDesugaring #-}' \
-                src/Text/Parse.hs \
-                src/Text/Parse/ByteString.hs
-            '';
-          });
-          profunctors = super.haskell.lib.overrideCabal hssuper.profunctors (attrs: {
-            postPatch = ''
-              ${attrs.postPatch or ""}
-              sed -i '
-                /import Data\.Functor\.Contravariant/s/import/import "contravariant"/;
-                1i{-# LANGUAGE PackageImports #-}' \
-                src/Data/Profunctor/Unsafe.hs \
-                src/Data/Profunctor/Strong.hs
             '';
           });
           semigroupoids = super.haskell.lib.overrideCabal hssuper.semigroupoids (attrs: {
@@ -137,25 +45,16 @@ self: super:
                 /containers >=/s/containers.*$/containers/
                 ' \
                 semigroupoids.cabal
-              sed -i '
-                /import Data\.Functor\.Contravariant/s/import/import "contravariant"/;
-                1i{-# LANGUAGE PackageImports #-}' \
-                src/Data/Semigroupoid.hs
-            '';
+              '';
           });
           unliftio = hssuper.unliftio.overrideAttrs (attrs: {
+            jailbreak = true;
             patchPhase = ''
               ${attrs.patchPhase or ""}
               sed -i '
                 168s/Int/Natural/;
                 /import/iimport GHC.Natural (Natural)
                 ' src/UnliftIO/STM.hs
-            '';
-          });
-          unordered-containers = hssuper.unordered-containers.overrideAttrs (attrs: {
-            patchPhase = ''
-              ${attrs.patchPhase or ""}
-              sed -i '230s/M\.fold/M.foldr/' tests/HashMapProperties.hs
             '';
           });
         };

--- a/nix/nixpkgs/src.json
+++ b/nix/nixpkgs/src.json
@@ -2,6 +2,6 @@
   "owner": "NixOS",
   "repo": "nixpkgs-channels",
   "branch": "nixpkgs-unstable",
-  "rev": "52a1179b6c20e923beddde1dd1e0034aa19176d2",
-  "sha256": "1dmaq97208mmgjlwis071v031spcq9j6nvlhisw3f52c02l9dbwf"
+  "rev": "89b618771ad4b0cfdb874dee3d51eb267c4257dd",
+  "sha256": "142yqfgg2gzwdkcpprakmym2ail4b6yrwqskwin6bw5lkaaizjni"
 }


### PR DESCRIPTION
Update to the latest revision in the nixpkgs-unstable channel.
This allows to remove some of the patches to dependencies, as these have
been updated for GHC 8.6 compatibility in the meantime.