### PR TITLE
Simplify export lists

### DIFF
--- a/src/Capability/Reader.hs
+++ b/src/Capability/Reader.hs
@@ -6,16 +6,9 @@
 
 module Capability.Reader
   ( -- * Interface
-    HasReader(..)
-  , ask
-  , asks
-  , local
-  , reader
-  , magnify
+    module Capability.Reader.Internal.Class
     -- * Strategies
-  , MonadReader(..)
-  , ReadStatePure(..)
-  , ReadState(..)
+  , module Capability.Reader.Internal.Strategies
     -- ** Modifiers
   , module Capability.Accessors
   ) where

--- a/src/Capability/Reader/Internal/Class.hs
+++ b/src/Capability/Reader/Internal/Class.hs
@@ -9,6 +9,8 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeInType #-}
 
+{-# OPTIONS_HADDOCK hide #-}
+
 module Capability.Reader.Internal.Class
   ( HasReader(..)
   , ask

--- a/src/Capability/Reader/Internal/Strategies.hs
+++ b/src/Capability/Reader/Internal/Strategies.hs
@@ -19,6 +19,8 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 {-# OPTIONS_GHC -Wno-simplifiable-class-constraints #-}
 
+{-# OPTIONS_HADDOCK hide #-}
+
 module Capability.Reader.Internal.Strategies
   ( MonadReader(..)
   , ReadStatePure(..)

--- a/src/Capability/State.hs
+++ b/src/Capability/State.hs
@@ -10,18 +10,9 @@
 
 module Capability.State
   ( -- * Interface
-    HasState(..)
-  , get
-  , put
-  , state
-  , modify
-  , modify'
-  , gets
-  , zoom
+    module Capability.State.Internal.Class
     -- * Strategies
-  , MonadState(..)
-  , ReaderIORef(..)
-  , ReaderRef(..)
+  , module Capability.State.Internal.Strategies
     -- ** Modifiers
   , module Capability.Accessors
   ) where

--- a/src/Capability/State/Internal/Class.hs
+++ b/src/Capability/State/Internal/Class.hs
@@ -9,6 +9,8 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeInType #-}
 
+{-# OPTIONS_HADDOCK hide #-}
+
 module Capability.State.Internal.Class
   ( HasState(..)
   , get
@@ -70,7 +72,7 @@ put = put_ (proxy# @_ @tag)
 -- monad @m@ with capability @HasState@.
 --
 -- Given the current state @s@ of the state capability @tag@
--- and @(a, s') = f s@, update the state to @s'@ and return @a@. 
+-- and @(a, s') = f s@, update the state to @s'@ and return @a@.
 state :: forall tag s m a. HasState tag s m => (s -> (a, s)) -> m a
 state = state_ (proxy# @_ @tag)
 {-# INLINE state #-}

--- a/src/Capability/State/Internal/Strategies.hs
+++ b/src/Capability/State/Internal/Strategies.hs
@@ -19,6 +19,8 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 {-# OPTIONS_GHC -Wno-simplifiable-class-constraints #-}
 
+{-# OPTIONS_HADDOCK hide #-}
+
 module Capability.State.Internal.Strategies
   ( MonadState(..)
   , ReaderIORef(..)


### PR DESCRIPTION
This is done using the Haddock `hide` attribute. Which has two
effects:

- expanding out re-exported entities as if they were defined in the
  re-exporting module. This means that we can re-export whole modules
  rather than have to list each of the entities separately and run the
  risk of missing one.

- internal modules don't show up in the module index anymore. This is
  fine, because the internal modules we have are not really internal.
  They're not exposing anything that isn't reexported elsewhere. The
  only reason we have them is for internal code organization. That
  concern is immaterial for consumers of the library.