### PR TITLE
Relax a restriction of generic-lens

### DIFF
--- a/capability.cabal
+++ b/capability.cabal
@@ -47,7 +47,7 @@ library
       base >= 4.12 && < 5.0
     , dlist >= 0.8 && < 0.9
     , exceptions >= 0.6 && < 0.11
-    , generic-lens >= 1.0 && < 1.1
+    , generic-lens >= 1.0 && < 1.2
     , lens >= 4.16 && < 5.0
     , monad-control >= 1.0 && < 1.1
     , monad-unlift >= 0.2 && < 0.3


### PR DESCRIPTION
New release of `generic-lens` was available.
And now, the version is standard on stackage: https://stackage.org/package/generic-lens .

Please relax the restriction of `generic-lens` for dependency resolver.

See also: https://github.com/kcsongor/generic-lens/compare/1.0.0.2...1.1.0.0