### PR TITLE
Release version 0.2.0.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,12 @@
 # Revision history for capability
 
+## 0.2.0.0 -- 2019-03-22
+
+* Make HasStream a superclass of HasWriter.
+  See [#64](https://github.com/tweag/capability/pull/64)
+* Bumped version bounds on generic-lens.
+  See [#67](https://github.com/tweag/capability/pull/67)
+
 ## 0.1.0.0 -- 2018-10-04
 
 * Initial release.

--- a/capability.cabal
+++ b/capability.cabal
@@ -1,5 +1,5 @@
 name: capability
-version: 0.1.0.0
+version: 0.2.0.0
 homepage: https://github.com/tweag/capability
 license: BSD3
 license-file: LICENSE


### PR DESCRIPTION
- Bump version number
- Update changelog

See package candidate: https://hackage.haskell.org/package/capability-0.2.0.0/candidate