### PR TITLE
Pin nixpkgs in nix2 style

### DIFF
--- a/nix/nixpkgs/default.nix
+++ b/nix/nixpkgs/default.nix
@@ -1,27 +1,9 @@
-# https://github.com/NixOS/nixpkgs/pull/30399#issuecomment-340420000
-#
-# Pure fetchTarball with sha256 that works in nix 1.11. This will go away
-# once using nix 1.12+.
 let
   spec = builtins.fromJSON (builtins.readFile ./src.json);
-  src = import <nix/fetchurl.nix> {
+  src = {
     url = "https://github.com/${spec.owner}/${spec.repo}/archive/${spec.rev}.tar.gz";
     inherit (spec) sha256;
   };
-  nixcfg = import <nix/config.nix>;
-in builtins.derivation {
-  system = builtins.currentSystem;
-  name = "${src.name}-unpacked";
-  builder = nixcfg.shell;
-  inherit src;
-  args = [
-    (builtins.toFile "builder" ''
-      $coreutils/mkdir $out
-      cd $out
-      $gzip -d < $src | $tar -x --strip-components=1
-    '')
-  ];
-  coreutils = builtins.storePath nixcfg.coreutils;
-  tar = builtins.storePath nixcfg.tar;
-  gzip = builtins.storePath nixcfg.gzip;
-}
+
+in 
+  builtins.fetchTarball src

--- a/nix/nixpkgs/src.json
+++ b/nix/nixpkgs/src.json
@@ -3,5 +3,5 @@
   "repo": "nixpkgs-channels",
   "branch": "nixpkgs-unstable",
   "rev": "89b618771ad4b0cfdb874dee3d51eb267c4257dd",
-  "sha256": "142yqfgg2gzwdkcpprakmym2ail4b6yrwqskwin6bw5lkaaizjni"
+  "sha256": "0jlyggy7pvqj2a6iyn44r7pscz9ixjb6fn6s4ssvahfywsncza6y"
 }


### PR DESCRIPTION
Running `nix-shell` fails due to `builder = nixcfg.shell;` being impure (see NixOS/nixpkgs#30399).
This commit fixes this by using the idiomatic nix2 method of nixpkgs pinning. The `sha256` has changed as it is now the hash of the unpacked archive.
See: https://github.com/tweag/capability/issues/69