### PR TITLE
Removing spurious tag ~ field constraints

### DIFF
--- a/src/Capability/Reader/Internal/Strategies.hs
+++ b/src/Capability/Reader/Internal/Strategies.hs
@@ -151,7 +151,7 @@ instance
   -- The constraint raises @-Wsimplifiable-class-constraints@.
   -- This could be avoided by instead placing @HasField'@s constraints here.
   -- Unfortunately, it uses non-exported symbols from @generic-lens@.
-  ( tag ~ field, Generic.HasField' field record v, HasReader oldtag record m )
+  ( Generic.HasField' field record v, HasReader oldtag record m )
   => HasReader tag v (Field field oldtag m)
   where
     ask_ _ = coerce @(m v) $

--- a/src/Capability/State/Internal/Strategies.hs
+++ b/src/Capability/State/Internal/Strategies.hs
@@ -85,7 +85,7 @@ instance
   -- The constraint raises @-Wsimplifiable-class-constraints@.
   -- This could be avoided by instead placing @HasField'@s constraints here.
   -- Unfortunately, it uses non-exported symbols from @generic-lens@.
-  ( tag ~ field, Generic.HasField' field record v, HasState oldtag record m )
+  ( Generic.HasField' field record v, HasState oldtag record m )
   => HasState tag v (Field field oldtag m)
   where
     get_ _ = coerce @(m v) $


### PR DESCRIPTION
The `Field` strategies for deriving `HasReader` and `HasState` instances impose a seemlingly spurious constraint that the `generic-lens` field name should match the tag. This effectively forces tags to be `Symbol`'s when using these strategies, even if the classes are poly-kinded.