### PR TITLE
Introducing `TypeOf` type family

### DIFF
--- a/capability.cabal
+++ b/capability.cabal
@@ -41,6 +41,7 @@ library
     Capability.State.Internal.Class
     Capability.State.Internal.Strategies
     Capability.Stream
+    Capability.TypeOf
     Capability.Writer
     Capability.Writer.Discouraged
   build-depends:

--- a/examples/Reader.hs
+++ b/examples/Reader.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}

--- a/src/Capability/Error.hs
+++ b/src/Capability/Error.hs
@@ -24,6 +24,7 @@
 -- thrown under @"foo"@.
 
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
@@ -47,8 +48,10 @@
 module Capability.Error
   ( -- * Interface
     HasThrow(..)
+  , HasThrow'
   , throw
   , HasCatch(..)
+  , HasCatch'
   , catch
   , catchJust
   , wrapError
@@ -66,6 +69,7 @@ module Capability.Error
   ) where
 
 import Capability.Accessors
+import Capability.TypeOf
 import Control.Exception (Exception(..))
 import qualified Control.Exception.Safe as Safe
 import Control.Lens (preview, review)
@@ -421,3 +425,11 @@ deriving via ((t2 :: (* -> *) -> * -> *) ((t1 :: (* -> *) -> * -> *) m))
   ( forall x. Coercible (m x) (t2 (t1 m) x)
   , Monad m, HasCatch tag e (t2 (t1 m)) )
   => HasCatch tag e ((t2 :.: t1) m)
+
+-- | Type synonym using the 'TypeOf' type family to specify 'HasThrow'
+-- constraints without having to specify the type associated to a tag.
+type HasThrow' (tag :: k) = HasThrow tag (TypeOf k tag)
+
+-- | Type synonym using the 'TypeOf' type family to specify 'HasCatch'
+-- constraints without having to specify the type associated to a tag.
+type HasCatch' (tag :: k) = HasCatch tag (TypeOf k tag)

--- a/src/Capability/Reader.hs
+++ b/src/Capability/Reader.hs
@@ -1,3 +1,7 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE TypeInType #-}
+
 -- | Defines a capability type class for a reader effect. A reader provides an
 -- environment, say an initialization context or a configuration. The
 -- environment held in the reader effect can be changed (with 'local') within
@@ -11,8 +15,15 @@ module Capability.Reader
   , module Capability.Reader.Internal.Strategies
     -- ** Modifiers
   , module Capability.Accessors
+  , module Capability.TypeOf
+  , HasReader'
   ) where
 
 import Capability.Accessors
 import Capability.Reader.Internal.Class
 import Capability.Reader.Internal.Strategies
+import Capability.TypeOf
+
+-- | Type synonym using the 'TypeOf' type family to specify 'HasReader'
+-- constraints without having to specify the type associated to a tag.
+type HasReader' (tag :: k) = HasReader tag (TypeOf k tag)

--- a/src/Capability/State.hs
+++ b/src/Capability/State.hs
@@ -1,3 +1,7 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE TypeInType #-}
+
 -- | Defines a capability type class for a state effect. A state capability
 -- provides a state which can be retrieved with 'get' and set with 'put'. As an
 -- analogy, each state capability is equivalent to making one @IORef@ available
@@ -15,8 +19,15 @@ module Capability.State
   , module Capability.State.Internal.Strategies
     -- ** Modifiers
   , module Capability.Accessors
+  , module Capability.TypeOf
+  , HasState'
   ) where
 
 import Capability.Accessors
 import Capability.State.Internal.Class
 import Capability.State.Internal.Strategies
+import Capability.TypeOf
+
+-- | Type synonym using the 'TypeOf' type family to specify 'HasState'
+-- constraints without having to specify the type associated to a tag.
+type HasState' (tag :: k) = HasState tag (TypeOf k tag)

--- a/src/Capability/Stream.hs
+++ b/src/Capability/Stream.hs
@@ -16,6 +16,7 @@
 -- using this capability can be consumed efficiently in a streaming fashion.
 
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -36,6 +37,7 @@
 module Capability.Stream
   ( -- * Interface
     HasStream(..)
+  , HasStream'
   , yield
     -- * Strategies
   , StreamStack(..)
@@ -138,3 +140,7 @@ deriving via ((t2 :: (* -> *) -> * -> *) ((t1 :: (* -> *) -> * -> *) m))
   ( forall x. Coercible (m x) (t2 (t1 m) x)
   , Monad m, HasStream tag a (t2 (t1 m)) )
   => HasStream tag a ((t2 :.: t1) m)
+
+-- | Type synonym using the 'TypeOf' type family to specify 'HasStream'
+-- constraints without having to specify the type associated to a tag.
+type HasStream' (tag :: k) = HasStream tag (TypeOf k tag)

--- a/src/Capability/TypeOf.hs
+++ b/src/Capability/TypeOf.hs
@@ -8,22 +8,31 @@ module Capability.TypeOf where
 -- simplify constraint declarations, by removing the need to redundantly specify
 -- the type associated to a tag.
 --
--- It is poly-kinded, which allows users to define their own type of tags, and
--- not have to declare orphan type family instances.
+-- It is poly-kinded, which allows users to define their own kind of tags.
+-- Standard haskell types can also be used as tags by specifying the '*' kind
+-- when defining the type family instance.
+--
+-- Defining 'TypeOf' instances for 'GHC.TypeLits.Symbol's (typelevel string
+-- literals) is discouraged. Since symbols all belong to the same global
+-- namespace, such instances could conflict with others defined in external
+-- libraries. More generally, as for typeclasses, 'TypeOf' instances should
+-- always be defined in the same module as the tag type to prevent issues due to
+-- orphan instances.
 --
 -- Example:
 -- @
---     {-# LANGUAGE DataKinds #-}
+--     {-# LANGUAGE EmptyDataDecls #-}
 --     {-# LANGUAGE TypeFamilies #-}
 --
 --     import Capability.Reader
 --
---     data Tag = Foo | Bar
---     type instance TypeOf 'Foo = Int
---     type instance TypeOf 'Tag = String
+--     data Foo
+--     data Bar
+--     type instance TypeOf * Foo = Int
+--     type instance TypeOf * Bar = String
 --
 --     -- Same as: foo :: HasReader Foo Int M => …
---     foo :: HasReader' 'Foo m => …
+--     foo :: HasReader' Foo m => …
 --     foo = …
 -- @
 type family TypeOf k (s :: k) :: *

--- a/src/Capability/TypeOf.hs
+++ b/src/Capability/TypeOf.hs
@@ -20,10 +20,8 @@ module Capability.TypeOf where
 -- orphan instances.
 --
 -- Example:
--- @
---     {-# LANGUAGE EmptyDataDecls #-}
---     {-# LANGUAGE TypeFamilies #-}
 --
+-- @
 --     import Capability.Reader
 --
 --     data Foo

--- a/src/Capability/TypeOf.hs
+++ b/src/Capability/TypeOf.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeInType #-}
+
+module Capability.TypeOf where
+
+-- | Type family associating a tag to the corresponding type. It is intended to
+-- simplify constraint declarations, by removing the need to redundantly specify
+-- the type associated to a tag.
+--
+-- It is poly-kinded, which allows users to define their own type of tags, and
+-- not have to declare orphan type family instances.
+--
+-- Example:
+-- @
+--     {-# LANGUAGE DataKinds #-}
+--     {-# LANGUAGE TypeFamilies #-}
+--
+--     import Capability.Reader
+--
+--     data Tag = Foo | Bar
+--     type instance TypeOf 'Foo = Int
+--     type instance TypeOf 'Tag = String
+--
+--     -- Same as: foo :: HasReader Foo Int M => …
+--     foo :: HasReader' 'Foo m => …
+--     foo = …
+-- @
+type family TypeOf k (s :: k) :: *

--- a/src/Capability/Writer.hs
+++ b/src/Capability/Writer.hs
@@ -17,6 +17,7 @@
 -- and does not misuse the underlying state monad.
 
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -41,6 +42,7 @@
 module Capability.Writer
   ( -- * Interface
     HasWriter(..)
+  , HasWriter'
   , writer
   , tell
   , listen
@@ -167,3 +169,7 @@ instance (Monoid w, HasState tag w m)
       put @tag $! w0 <> f w
       pure a
     {-# INLINE pass_ #-}
+
+-- | Type synonym using the 'TypeOf' type family to specify 'HasWriter'
+-- constraints without having to specify the type associated to a tag.
+type HasWriter' (tag :: k) = HasWriter tag (TypeOf k tag)


### PR DESCRIPTION
Fixes #65.

Introduces a poly-kinded type family to allow users to associate tags to type, and corresponding type synonyms for all capabilities to shorten constraint declarations.

Also changes the 'Reader' example to make use of this feature.