### PR TITLE
Capability-retaining `zoom` and `magnify`

### DIFF
--- a/capability.cabal
+++ b/capability.cabal
@@ -33,6 +33,7 @@ library
   exposed-modules:
     Capability
     Capability.Accessors
+    Capability.Constraints
     Capability.Error
     Capability.Reader
     Capability.Reader.Internal.Class

--- a/capability.cabal
+++ b/capability.cabal
@@ -47,6 +47,7 @@ library
     Capability.Writer.Discouraged
   build-depends:
       base >= 4.12 && < 5.0
+    , constraints >= 0.1 && < 0.12
     , dlist >= 0.8 && < 0.9
     , exceptions >= 0.6 && < 0.11
     , generic-lens >= 1.0 && < 1.2

--- a/examples/State.hs
+++ b/examples/State.hs
@@ -1,7 +1,9 @@
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeApplications #-}
@@ -25,6 +27,9 @@ import Test.Hspec
 incFoo :: HasState "foo" Int m => m ()
 incFoo = modify @"foo" (+1)
 
+incFoobar :: HasState "foobar" (Int,Int) m => m ()
+incFoobar = modify @"foobar" $ \(x,y) -> (x+1, y+1)
+
 twoStates :: (HasState "foo" Int m, HasState "bar" Int m) => m ()
 twoStates = do
   incFoo
@@ -34,9 +39,13 @@ twoStates = do
 useZoom :: HasState "foobar" (Int, Int) m => m Int
 useZoom = do
   put @"foobar" (2, 2)
-  -- Zoom in on the first element in the current state, rename tag 1 to "foo".
-  zoom @"foobar" @"foo" @(Rename 1 :.: Pos 1 "foobar") $
-    incFoo
+  -- Zoom in on the first element in the current state, renaming tag 1 to "foo",
+  -- while retaining the original 'HasState "foobar" (Int, Int)' capability.
+  zoom
+    @"foobar" @"foo" @(Rename 1 :.: Pos 1 "foobar")
+    @('[HasState "foobar" (Int,Int)]) $ do
+      incFoo
+      incFoobar
   gets @"foobar" (\(foo, bar) -> foo + bar)
 
 
@@ -123,4 +132,4 @@ spec = do
       runNestedStatesM twoStates `shouldBe` (((), 1), -1)
   describe "runFooBarState" $
     it "evaluates useZoom" $
-      runFooBarState useZoom (0, 0) `shouldBe` (5, (3, 2))
+      runFooBarState useZoom (0, 0) `shouldBe` (7, (4, 3))

--- a/src/Capability/Constraints.hs
+++ b/src/Capability/Constraints.hs
@@ -12,7 +12,6 @@ module Capability.Constraints
   ( All
   , Constraint
   , Dict(..)
-  , None
   ) where
 
 import Data.Kind (Constraint)
@@ -36,9 +35,3 @@ data Dict (c :: Constraint) = c => Dict
 type family All (xs :: [k -> Constraint]) a :: Constraint where
   All '[] a = ()
   All (x ':xs) a = (x a, All xs a)
-
--- | Convenience type synonym representing an empty set of capabilities.
---
--- This is useful, because GHC infers @'[]@ as being of kind @[*]@ without an
--- extra kind annotation.
-type None = ('[] :: [k -> Constraint])

--- a/src/Capability/Constraints.hs
+++ b/src/Capability/Constraints.hs
@@ -14,14 +14,8 @@ module Capability.Constraints
   , Dict(..)
   ) where
 
+import Data.Constraint (Dict(..))
 import Data.Kind (Constraint)
-
--- | Evidence of a constraint that can be passed around as a value. Matching on
--- the constructor brings the constraint into scope.
---
--- This is the same as the @Dict@ datatype defined in the @constraints@ package,
--- but redefined here to avoid the dependency.
-data Dict (c :: Constraint) = c => Dict
 
 -- | Type family used used to apply a list of capabilities to a single type.
 --

--- a/src/Capability/Constraints.hs
+++ b/src/Capability/Constraints.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeInType #-}
+{-# LANGUAGE TypeOperators #-}
+
+-- | This module defines helper types and type families for working with sets of
+-- capabilities.
+
+module Capability.Constraints
+  ( All
+  , Constraint
+  , Dict(..)
+  , None
+  ) where
+
+import Data.Kind (Constraint)
+
+-- | Evidence of a constraint that can be passed around as a value. Matching on
+-- the constructor brings the constraint into scope.
+--
+-- This is similar to the @Dict@ datatype defined in the @constraints@ package,
+-- but redefined here to avoid the dependence.
+data Dict (c :: Constraint) = c => Dict
+
+-- | Type family used used to apply a list of capabilities to a single type.
+--
+-- Examples:
+--
+-- > All '[Num, Eq] Int
+-- >   -- Equivalent to: (Num Int, Eq Int)
+-- >
+-- > All '[HasReader "foo" Int, HasStream "bar" Float] m
+-- >   -- Equivalent to: (HasReader "foo" Int m, HasStream "bar" Float m)
+type family All (xs :: [k -> Constraint]) a :: Constraint where
+  All '[] a = ()
+  All (x ':xs) a = (x a, All xs a)
+
+-- | Convenient type synonym representing an empty set of capabilities.
+--
+-- This is useful, because GHC infers @'[]@ as being of kind @[*]@ without an
+-- extra kind annotation.
+type None = ('[] :: [k -> Constraint])

--- a/src/Capability/Constraints.hs
+++ b/src/Capability/Constraints.hs
@@ -20,8 +20,8 @@ import Data.Kind (Constraint)
 -- | Evidence of a constraint that can be passed around as a value. Matching on
 -- the constructor brings the constraint into scope.
 --
--- This is similar to the @Dict@ datatype defined in the @constraints@ package,
--- but redefined here to avoid the dependence.
+-- This is the same as the @Dict@ datatype defined in the @constraints@ package,
+-- but redefined here to avoid the dependency.
 data Dict (c :: Constraint) = c => Dict
 
 -- | Type family used used to apply a list of capabilities to a single type.
@@ -37,7 +37,7 @@ type family All (xs :: [k -> Constraint]) a :: Constraint where
   All '[] a = ()
   All (x ':xs) a = (x a, All xs a)
 
--- | Convenient type synonym representing an empty set of capabilities.
+-- | Convenience type synonym representing an empty set of capabilities.
 --
 -- This is useful, because GHC infers @'[]@ as being of kind @[*]@ without an
 -- extra kind annotation.

--- a/src/Capability/Reader.hs
+++ b/src/Capability/Reader.hs
@@ -15,11 +15,14 @@ module Capability.Reader
   , module Capability.Reader.Internal.Strategies
     -- ** Modifiers
   , module Capability.Accessors
+    -- * Helpers
+  , module Capability.Constraints
   , module Capability.TypeOf
   , HasReader'
   ) where
 
 import Capability.Accessors
+import Capability.Constraints
 import Capability.Reader.Internal.Class
 import Capability.Reader.Internal.Strategies
 import Capability.TypeOf

--- a/src/Capability/Reader/Internal/Class.hs
+++ b/src/Capability/Reader/Internal/Class.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE KindSignatures #-}
@@ -7,6 +8,7 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE TypeInType #-}
 
 {-# OPTIONS_HADDOCK hide #-}
@@ -20,8 +22,10 @@ module Capability.Reader.Internal.Class
   , magnify
   ) where
 
-import Data.Coerce (Coercible, coerce)
+import Capability.Constraints
+import Data.Coerce (Coercible)
 import GHC.Exts (Proxy#, proxy#)
+import Unsafe.Coerce (unsafeCoerce)
 
 -- | Reader capability
 --
@@ -88,17 +92,25 @@ reader = reader_ (proxy# @_ @tag)
 {-# INLINE reader #-}
 
 -- | Execute the given reader action on a sub-component of the current context
--- as defined by the given transformer @t@.
+-- as defined by the given transformer @t@, retaining arbitrary capabilities.
 --
 -- See 'Capability.State.zoom'.
 --
 -- This function is experimental and subject to change.
 -- See <https://github.com/tweag/capability/issues/46>.
-magnify :: forall outertag innertag t outer inner m a.
+magnify :: forall outertag innertag t (cs :: [(* -> *) -> Constraint]) outer inner m a.
   ( forall x. Coercible (t m x) (m x)
   , forall m'. HasReader outertag outer m'
     => HasReader innertag inner (t m')
-  , HasReader outertag outer m )
-  => (forall m'. HasReader innertag inner m' => m' a) -> m a
-magnify m = coerce @(t m a) m
+  , HasReader outertag outer m
+  , All cs m)
+  => (forall m'. All (HasReader innertag inner ': cs) m' => m' a) -> m a
+magnify action =
+  -- See comment in 'Capability.State.zoom'.
+  let constraintsDict =
+        unsafeCoerce
+          @(Dict (HasReader innertag inner (t m)))
+          @(Dict (HasReader innertag inner m)) Dict in
+  case constraintsDict of
+    Dict -> action
 {-# INLINE magnify #-}

--- a/src/Capability/Reader/Internal/Class.hs
+++ b/src/Capability/Reader/Internal/Class.hs
@@ -92,9 +92,11 @@ reader = reader_ (proxy# @_ @tag)
 {-# INLINE reader #-}
 
 -- | Execute the given reader action on a sub-component of the current context
--- as defined by the given transformer @t@, retaining arbitrary capabilities.
+-- as defined by the given transformer @t@, retaining arbitrary capabilities
+-- listed in @cs@.
 --
--- See 'Capability.State.zoom'.
+-- See the similar 'Capability.State.zoom' function for more details and
+-- examples.
 --
 -- This function is experimental and subject to change.
 -- See <https://github.com/tweag/capability/issues/46>.

--- a/src/Capability/State.hs
+++ b/src/Capability/State.hs
@@ -19,11 +19,14 @@ module Capability.State
   , module Capability.State.Internal.Strategies
     -- ** Modifiers
   , module Capability.Accessors
+    -- * Helpers
+  , module Capability.Constraints
   , module Capability.TypeOf
   , HasState'
   ) where
 
 import Capability.Accessors
+import Capability.Constraints
 import Capability.State.Internal.Class
 import Capability.State.Internal.Strategies
 import Capability.TypeOf

--- a/src/Capability/State/Internal/Class.hs
+++ b/src/Capability/State/Internal/Class.hs
@@ -110,7 +110,7 @@ gets f = do
 
 -- | Execute the given state action on a sub-component of the current state as
 -- defined by the given transformer @t@. The set of retained capabilities must
--- be passed as an extra type parameter. If no capabilities are required,
+-- be passed as @cs. If no capabilities are required,
 -- 'Capabilities.Constraints.None' can be used.
 --
 -- Examples:
@@ -139,7 +139,7 @@ zoom :: forall outertag innertag t (cs :: [(* -> *) -> Constraint]) outer inner 
   => (forall m'. All (HasState innertag inner ': cs) m' => m' a) -> m a
 zoom action =
   let constraintsDict =
-        -- Note: this use of 'unsafeCoerce' should be safe thanks the Coercible
+        -- Note: this use of 'unsafeCoerce' is safe thanks the Coercible
         -- constraint between 'm x' and 't m x'. However, dictionaries
         -- themselves aren't coercible since the type role of 'c' in 'Dict c' is
         -- nominal.


### PR DESCRIPTION
This change allows callers of the `Capability.State.zoom` and `Capability.Reader.magnify` functions to pass along a set of capabilities from the current monadic context to the focusing action. Retained capabilities are specified via a typelevel parameter of kind `[(* -> *) -> Constraint]`.

Implementation relies on `unsafeCoerce` to convert a dictionary for a wrapped monad instance to the original monad.

Fixes #46.