### PR TITLE
Allow arbitrary capability derivations

### DIFF
--- a/capability.cabal
+++ b/capability.cabal
@@ -34,6 +34,7 @@ library
     Capability
     Capability.Accessors
     Capability.Constraints
+    Capability.Context
     Capability.Error
     Capability.Reader
     Capability.Reader.Internal.Class

--- a/examples/Error.hs
+++ b/examples/Error.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
@@ -80,10 +81,10 @@ calculator = do
         do
           -- Errors in the parser or math component are converted to a
           -- @CalcError@ by wrapping with the corresponding constructor.
-          let wrapParserError = wrapError @"calc" @"parser"
-                @(Rename "ParserError" :.: Ctor "ParserError" "calc")
-              wrapMathError = wrapError @"calc" @"math"
-                @(Rename "MathError" :.: Ctor "MathError" "calc")
+          let wrapParserError = wrapError @"parser"
+                @(Rename "ParserError" :.: Ctor "ParserError" "calc") @'[]
+              wrapMathError = wrapError @"math"
+                @(Rename "MathError" :.: Ctor "MathError" "calc") @'[]
           num <- wrapParserError $ parseNumber input
           root <- wrapMathError $ sqrtNumber num
           liftIO $ putStrLn $ "sqrt = " ++ show root

--- a/examples/Reader.hs
+++ b/examples/Reader.hs
@@ -52,8 +52,10 @@ fooBarExample = do
 fooBarMagnify
   :: (HasReader "foobar" FooBar m, MonadIO m) => m ()
 fooBarMagnify = do
-  magnify @"foobar" @"foo"
-    @(Field "foo" "foobar") @('[HasReader "foobar" FooBar, MonadIO]) $ do
+  magnify
+    @"foo"
+    @(Field "foo" "foobar")
+    @('[HasReader "foobar" FooBar, MonadIO]) $ do
       FooBar a b <- local @"foo" (const 5) (ask @"foobar")
       c <- local @"foobar" (const $ FooBar 3 4) (ask @"foo")
       liftIO $ print ((a, b), c)

--- a/examples/State.hs
+++ b/examples/State.hs
@@ -42,7 +42,7 @@ useZoom = do
   -- Zoom in on the first element in the current state, renaming tag 1 to "foo",
   -- while retaining the original 'HasState "foobar" (Int, Int)' capability.
   zoom
-    @"foobar" @"foo" @(Rename 1 :.: Pos 1 "foobar")
+    @"foo" @(Rename 1 :.: Pos 1 "foobar")
     @('[HasState "foobar" (Int,Int)]) $ do
       incFoo
       incFoobar

--- a/src/Capability/Constraints.hs
+++ b/src/Capability/Constraints.hs
@@ -10,6 +10,7 @@
 
 module Capability.Constraints
   ( All
+  , Capability
   , Constraint
   , Dict(..)
   ) where
@@ -17,7 +18,13 @@ module Capability.Constraints
 import Data.Constraint (Dict(..))
 import Data.Kind (Constraint)
 
--- | Type family used used to apply a list of capabilities to a single type.
+-- | A 'Capability' takes a type constructor @* -> *@ (e.g., a monad) and
+-- returns a 'Constraint'. Examples of capabilities includ: @HasReader "foo"
+-- Int@, @MonadIO@, …
+type Capability = (* -> *) -> Constraint
+
+-- | Type family used used to express a conjunction of constraints over a single
+-- type.
 --
 -- Examples:
 --

--- a/src/Capability/Context.hs
+++ b/src/Capability/Context.hs
@@ -16,7 +16,7 @@ import Data.Coerce (Coercible)
 import Unsafe.Coerce (unsafeCoerce)
 
 -- | Execute the given action with an additional @inner@ capability derived from
--- @outer@ via the @t@ wrapper, retaining the list @cs@ of capabilities.
+-- current context via the @t@ wrapper, retaining the list @cs@ of capabilities.
 context ::
   forall t (inner :: Capability) (cs :: [Capability]) m a.
   ( forall x. Coercible (t m x) (m x)

--- a/src/Capability/Context.hs
+++ b/src/Capability/Context.hs
@@ -18,19 +18,19 @@ import Unsafe.Coerce (unsafeCoerce)
 -- | Execute the given action with an additional @inner@ capability derived from
 -- current context via the @t@ wrapper, retaining the list @cs@ of capabilities.
 context ::
-  forall t (inner :: Capability) (cs :: [Capability]) m a.
+  forall t (derived :: Capability) (ambient :: [Capability]) m a.
   ( forall x. Coercible (t m x) (m x)
-  , inner (t m)
-  , All cs m)
-  => (forall m'. All (inner ': cs) m' => m' a) -> m a
+  , derived (t m)
+  , All ambient m)
+  => (forall m'. All (derived ': ambient) m' => m' a) -> m a
 context action =
-  let tmDict = Dict @(inner (t m))
+  let tmDict = Dict @(derived (t m))
       mDict =
         -- Note: this use of 'unsafeCoerce' should be safe thanks the Coercible
         -- constraint between 'm x' and 't m x'. However, dictionaries
         -- themselves aren't coercible since the type role of 'c' in 'Dict c' is
         -- nominal.
-        unsafeCoerce @_ @(Dict (inner m)) tmDict in
+        unsafeCoerce @_ @(Dict (derived m)) tmDict in
   case mDict of
     Dict -> action
 {-# INLINE context #-}

--- a/src/Capability/Context.hs
+++ b/src/Capability/Context.hs
@@ -17,10 +17,9 @@ import Unsafe.Coerce (unsafeCoerce)
 -- | Execute the given action with an additional @inner@ capability derived from
 -- @outer@ via the @t@ wrapper, retaining the list @cs@ of capabilities.
 context ::
-  forall t (outer :: Capability) (inner :: Capability) (cs :: [Capability]) m a.
+  forall t (inner :: Capability) (cs :: [Capability]) m a.
   ( forall x. Coercible (t m x) (m x)
-  , forall m'. outer m' => inner (t m')
-  , outer m
+  , inner (t m)
   , All cs m)
   => (forall m'. All (inner ': cs) m' => m' a) -> m a
 context action =

--- a/src/Capability/Context.hs
+++ b/src/Capability/Context.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE ConstraintKinds #-}

--- a/src/Capability/Context.hs
+++ b/src/Capability/Context.hs
@@ -18,19 +18,19 @@ import Unsafe.Coerce (unsafeCoerce)
 -- | Execute the given action with an additional @inner@ capability derived from
 -- current context via the @t@ wrapper, retaining the list @cs@ of capabilities.
 context ::
-  forall t (derived :: Capability) (ambient :: [Capability]) m a.
+  forall t (derived :: [Capability]) (ambient :: [Capability]) m a.
   ( forall x. Coercible (t m x) (m x)
-  , derived (t m)
+  , All derived (t m)
   , All ambient m)
-  => (forall m'. All (derived ': ambient) m' => m' a) -> m a
+  => (forall m'. (All derived m', All ambient m') => m' a) -> m a
 context action =
-  let tmDict = Dict @(derived (t m))
+  let tmDict = Dict @(All derived (t m))
       mDict =
         -- Note: this use of 'unsafeCoerce' should be safe thanks the Coercible
         -- constraint between 'm x' and 't m x'. However, dictionaries
         -- themselves aren't coercible since the type role of 'c' in 'Dict c' is
         -- nominal.
-        unsafeCoerce @_ @(Dict (derived m)) tmDict in
+        unsafeCoerce @_ @(Dict (All derived m)) tmDict in
   case mDict of
     Dict -> action
 {-# INLINE context #-}

--- a/src/Capability/Context.hs
+++ b/src/Capability/Context.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Capability.Context where
+
+import Capability.Constraints
+import Data.Coerce (Coercible)
+import Unsafe.Coerce (unsafeCoerce)
+
+-- | Execute the given action with an additional @inner@ capability derived from
+-- @outer@ via the @t@ wrapper, retaining the list @cs@ of capabilities.
+context ::
+  forall t (outer :: Capability) (inner :: Capability) (cs :: [Capability]) m a.
+  ( forall x. Coercible (t m x) (m x)
+  , forall m'. outer m' => inner (t m')
+  , outer m
+  , All cs m)
+  => (forall m'. All (inner ': cs) m' => m' a) -> m a
+context action =
+  let tmDict = Dict @(inner (t m))
+      mDict =
+        -- Note: this use of 'unsafeCoerce' should be safe thanks the Coercible
+        -- constraint between 'm x' and 't m x'. However, dictionaries
+        -- themselves aren't coercible since the type role of 'c' in 'Dict c' is
+        -- nominal.
+        unsafeCoerce @_ @(Dict (inner m)) tmDict in
+  case mDict of
+    Dict -> action
+{-# INLINE context #-}

--- a/src/Capability/Error.hs
+++ b/src/Capability/Error.hs
@@ -69,6 +69,8 @@ module Capability.Error
   ) where
 
 import Capability.Accessors
+import Capability.Constraints
+import Capability.Context (context)
 import Capability.TypeOf
 import Control.Exception (Exception(..))
 import qualified Control.Exception.Safe as Safe
@@ -147,7 +149,7 @@ catchJust = catchJust_ (proxy# @_ @tag)
 {-# INLINE catchJust #-}
 
 -- | Wrap exceptions @inner@ originating from the given action according to
--- the accessor @t@.
+-- the accessor @t@. Retain arbitrary capabilities listed in @cs@.
 --
 -- Example:
 --
@@ -160,13 +162,20 @@ catchJust = catchJust_ (proxy# @_ @tag)
 --
 -- This function is experimental and subject to change.
 -- See <https://github.com/tweag/capability/issues/46>.
-wrapError :: forall outertag innertag t outer inner m a.
+wrapError :: forall innertag t (cs :: [Capability]) inner m a.
   ( forall x. Coercible (t m x) (m x)
-  , forall m'. HasCatch outertag outer m'
-    => HasCatch innertag inner (t m')
-  , HasCatch outertag outer m )
-  => (forall m'. HasCatch innertag inner m' => m' a) -> m a
-wrapError action = coerce @(t m a) action
+  , HasCatch innertag inner (t m)
+  , All cs m)
+  => (forall m'. All (HasCatch innertag inner ': cs) m' => m' a) -> m a
+wrapError =
+  context @t @(HasCatch innertag inner) @cs
+-- wrapError :: forall outertag innertag t outer inner m a.
+--   ( forall x. Coercible (t m x) (m x)
+--   , forall m'. HasCatch outertag outer m'
+--     => HasCatch innertag inner (t m')
+--   , HasCatch outertag outer m )
+--   => (forall m'. HasCatch innertag inner m' => m' a) -> m a
+-- wrapError action = coerce @(t m a) action
 {-# INLINE wrapError #-}
 
 -- XXX: Does it make sense to add a HasMask capability similar to @MonadMask@?

--- a/src/Capability/Error.hs
+++ b/src/Capability/Error.hs
@@ -154,7 +154,7 @@ catchJust = catchJust_ (proxy# @_ @tag)
 -- Example:
 --
 -- > wrapError
--- >   @"AppError" @"ComponentError" @(Ctor "ComponentError" "AppError")
+-- >   @"ComponentError" @(Ctor "ComponentError" "AppError") @'[]
 -- >   component
 -- >
 -- > component :: HasError "ComponentError" ComponentError m => m ()
@@ -168,7 +168,7 @@ wrapError :: forall innertag t (cs :: [Capability]) inner m a.
   , All cs m)
   => (forall m'. All (HasCatch innertag inner ': cs) m' => m' a) -> m a
 wrapError =
-  context @t @(HasCatch innertag inner) @cs
+  context @t @'[HasCatch innertag inner] @cs
 -- wrapError :: forall outertag innertag t outer inner m a.
 --   ( forall x. Coercible (t m x) (m x)
 --   , forall m'. HasCatch outertag outer m'

--- a/src/Capability/Reader/Internal/Class.hs
+++ b/src/Capability/Reader/Internal/Class.hs
@@ -105,5 +105,5 @@ magnify :: forall innertag t (cs :: [Capability]) inner m a.
   , All cs m)
   => (forall m'. All (HasReader innertag inner ': cs) m' => m' a) -> m a
 magnify =
-  context @t @(HasReader innertag inner) @cs
+  context @t @'[HasReader innertag inner] @cs
 {-# INLINE magnify #-}

--- a/src/Capability/Reader/Internal/Class.hs
+++ b/src/Capability/Reader/Internal/Class.hs
@@ -1,4 +1,3 @@
-{-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE KindSignatures #-}

--- a/src/Capability/Reader/Internal/Class.hs
+++ b/src/Capability/Reader/Internal/Class.hs
@@ -100,13 +100,11 @@ reader = reader_ (proxy# @_ @tag)
 --
 -- This function is experimental and subject to change.
 -- See <https://github.com/tweag/capability/issues/46>.
-magnify :: forall outertag innertag t (cs :: [Capability]) outer inner m a.
+magnify :: forall innertag t (cs :: [Capability]) inner m a.
   ( forall x. Coercible (t m x) (m x)
-  , forall m'. HasReader outertag outer m'
-    => HasReader innertag inner (t m')
-  , HasReader outertag outer m
+  , HasReader innertag inner (t m)
   , All cs m)
   => (forall m'. All (HasReader innertag inner ': cs) m' => m' a) -> m a
 magnify =
-  context @t @(HasReader outertag outer) @(HasReader innertag inner) @cs
+  context @t @(HasReader innertag inner) @cs
 {-# INLINE magnify #-}

--- a/src/Capability/Reader/Internal/Class.hs
+++ b/src/Capability/Reader/Internal/Class.hs
@@ -23,9 +23,9 @@ module Capability.Reader.Internal.Class
   ) where
 
 import Capability.Constraints
+import Capability.Context (context)
 import Data.Coerce (Coercible)
 import GHC.Exts (Proxy#, proxy#)
-import Unsafe.Coerce (unsafeCoerce)
 
 -- | Reader capability
 --
@@ -100,19 +100,13 @@ reader = reader_ (proxy# @_ @tag)
 --
 -- This function is experimental and subject to change.
 -- See <https://github.com/tweag/capability/issues/46>.
-magnify :: forall outertag innertag t (cs :: [(* -> *) -> Constraint]) outer inner m a.
+magnify :: forall outertag innertag t (cs :: [Capability]) outer inner m a.
   ( forall x. Coercible (t m x) (m x)
   , forall m'. HasReader outertag outer m'
     => HasReader innertag inner (t m')
   , HasReader outertag outer m
   , All cs m)
   => (forall m'. All (HasReader innertag inner ': cs) m' => m' a) -> m a
-magnify action =
-  -- See comment in 'Capability.State.zoom'.
-  let constraintsDict =
-        unsafeCoerce
-          @(Dict (HasReader innertag inner (t m)))
-          @(Dict (HasReader innertag inner m)) Dict in
-  case constraintsDict of
-    Dict -> action
+magnify =
+  context @t @(HasReader outertag outer) @(HasReader innertag inner) @cs
 {-# INLINE magnify #-}

--- a/src/Capability/State/Internal/Class.hs
+++ b/src/Capability/State/Internal/Class.hs
@@ -135,5 +135,5 @@ zoom :: forall innertag t (cs :: [Capability]) inner m a.
   , All cs m )
   => (forall m'. All (HasState innertag inner ': cs) m' => m' a) -> m a
 zoom =
-  context @t @(HasState innertag inner) @cs
+  context @t @'[HasState innertag inner] @cs
 {-# INLINE zoom #-}

--- a/src/Capability/State/Internal/Class.hs
+++ b/src/Capability/State/Internal/Class.hs
@@ -1,4 +1,3 @@
-{-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE KindSignatures #-}

--- a/src/Capability/State/Internal/Class.hs
+++ b/src/Capability/State/Internal/Class.hs
@@ -113,18 +113,19 @@ gets f = do
 --
 -- Examples:
 --
--- > zoom @"foobar" @"foo" @(Field "foo" "foobar") @None foo
--- >   :: HasState "foobar" FooBar m => m ()
--- >
 -- > foo :: HasState "foo" Int m => m ()
--- > data FooBar = FooBar { foo :: Int, bar :: String }
---
--- > zoom @"foobar" @"foo" @(Field "foo" "foobar") @('[MonadIO]) bar
--- >   :: (MonadIO m, HasState "foobar" FooBar m) => m ()
+-- > zoom @"foo" @(Field "foo" "foobar") @None foo
+-- >   :: (HasField' "foobar" record Int, HasState "foobar" record m) => m ()
+-- >
+-- > zoom @"foo" @(Field "foo" "foobar") @('[MonadIO]) bar
+-- >   :: ( HasField' "foobar" record Int, HasState "foobar" record m
+-- >      , MonadIO m) => m ()
 -- >
 -- > foo :: HasState "foo" Int m => m ()
 -- > bar :: (MonadIO m, HasState "foo" Int m) => m ()
--- > data FooBar = FooBar { foo :: Int, bar :: String }
+--
+-- Note: the 'Data.Generics.Product.Fields.HasField'' constraint comes from the
+-- @generic-lens@ package.
 --
 -- This function is experimental and subject to change.
 -- See <https://github.com/tweag/capability/issues/46>.

--- a/src/Capability/State/Internal/Class.hs
+++ b/src/Capability/State/Internal/Class.hs
@@ -129,13 +129,11 @@ gets f = do
 --
 -- This function is experimental and subject to change.
 -- See <https://github.com/tweag/capability/issues/46>.
-zoom :: forall outertag innertag t (cs :: [Capability]) outer inner m a.
+zoom :: forall innertag t (cs :: [Capability]) inner m a.
   ( forall x. Coercible (t m x) (m x)
-  , forall m'. HasState outertag outer m'
-    => HasState innertag inner (t m')
-  , HasState outertag outer m
+  , HasState innertag inner (t m)
   , All cs m )
   => (forall m'. All (HasState innertag inner ': cs) m' => m' a) -> m a
 zoom =
-  context @t @(HasState outertag outer) @(HasState innertag inner) @cs
+  context @t @(HasState innertag inner) @cs
 {-# INLINE zoom #-}


### PR DESCRIPTION
This PR introduces a `Capability.Context.context` function that generalizes the approach taken in #73 to allow users to derive arbitrary new capabilities from the current context via a specified newtype combinator. The `zoom` and `magnify` functions are rewritten in terms of this helper.

The interface of `zoom` and `magnify` is also simplified a bit. Previously, those had a constraint of the form:
```
forall m'. HasState outertag outer m' => HasState innertag inner (t m')
```
but it seems that those were not necessary. We now only request that:
```
HasState innertag inner (t m)
```
without quantifying over all `m'`s.

*NOTE:* Based on #73 ; change base branch before merging !