### PR TITLE
Introduce HasSource, and make superclasses

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,17 @@
 # Revision history for capability
 
+## 0.?.?.? -- ??
+
+* Rename HasStream to HasSink, for symmetry.
+  See [#75](https://github.com/tweag/capability/pull/75)
+
+* Introduce HasSource, a superclass of HasReader.
+  See [#75](https://github.com/tweag/capability/pull/75)
+
+* Make HasSource and HasSink superclasses of HasState.
+  See [#75](https://github.com/tweag/capability/pull/75)
+
+
 ## 0.2.0.0 -- 2019-03-22
 
 * Make HasStream a superclass of HasWriter.

--- a/capability.cabal
+++ b/capability.cabal
@@ -39,9 +39,16 @@ library
     Capability.Reader
     Capability.Reader.Internal.Class
     Capability.Reader.Internal.Strategies
+    Capability.Sink
+    Capability.Sink.Internal.Class
+    Capability.Sink.Internal.Strategies
+    Capability.Source
+    Capability.Source.Internal.Class
+    Capability.Source.Internal.Strategies
     Capability.State
     Capability.State.Internal.Class
     Capability.State.Internal.Strategies
+    Capability.State.Internal.Strategies.Common
     Capability.Stream
     Capability.TypeOf
     Capability.Writer
@@ -74,8 +81,8 @@ test-suite examples
     CountLog
     Error
     Reader
+    Sink
     State
-    Stream
     Test.Common
     Writer
   main-is: Test.hs

--- a/examples/Test.hs
+++ b/examples/Test.hs
@@ -15,7 +15,7 @@ import qualified CountLog
 import qualified Error
 import qualified Reader
 import qualified State
-import qualified Stream
+import qualified Sink
 import qualified Writer
 import qualified WordCount
 
@@ -26,7 +26,7 @@ spec = do
   describe "Error" Error.spec
   describe "Reader" Reader.spec
   describe "State" State.spec
-  describe "Stream" Stream.spec
+  describe "Sink" Sink.spec
   describe "Writer" Writer.spec
   describe "WordCount" WordCount.spec
 

--- a/src/Capability.hs
+++ b/src/Capability.hs
@@ -65,7 +65,20 @@
 -- * "Capability.State" state effects
 -- * "Capability.Writer" writer effects
 -- * "Capability.Error" throw and catch errors
--- * "Capability.Stream" streaming effect (aka generators)
+-- * "Capability.Source" streaming in effect
+-- * "Capability.Sink" streaming out effect (aka generators)
+--
+-- The effects are not all independent:
+--
+-- >     Source   Sink
+-- >     /   \    /   \
+-- >    /     \  /     \
+-- > Reader   State    Writer
+--
+-- "Capability.Source" and "Capability.Sink" have just a method each, and no laws.
+-- The bottom three, familiar from mtl, add methods and laws relating them.
+-- The use of tags allows one to have independent effects that share a superclass.
+-- E.g. @HasState "foo" Int@ and @HasWriter "bar" String@.
 --
 -- Some of the capability modules have a “discouraged” companion (such as
 -- "Capability.Writer.Discouraged"). These modules contain deriving-via

--- a/src/Capability/Constraints.hs
+++ b/src/Capability/Constraints.hs
@@ -31,8 +31,8 @@ type Capability = (* -> *) -> Constraint
 -- > All '[Num, Eq] Int
 -- >   -- Equivalent to: (Num Int, Eq Int)
 -- >
--- > All '[HasReader "foo" Int, HasStream "bar" Float] m
--- >   -- Equivalent to: (HasReader "foo" Int m, HasStream "bar" Float m)
+-- > All '[HasReader "foo" Int, HasSink "bar" Float] m
+-- >   -- Equivalent to: (HasReader "foo" Int m, HasSink "bar" Float m)
 type family All (xs :: [k -> Constraint]) a :: Constraint where
   All '[] a = ()
   All (x ':xs) a = (x a, All xs a)

--- a/src/Capability/Sink.hs
+++ b/src/Capability/Sink.hs
@@ -1,0 +1,45 @@
+-- | Defines a capability for computations that produce a stream of values
+-- as part of their execution.
+--
+-- Programs producing streams of data are common. Examples: emitting events on
+-- input, or emitting events whenever certain conditions are observed. streams
+-- are similar to Python generators.
+--
+-- The 'HasSink' capability enables separating the logic responsible for
+-- emitting events from that responsible for collecting or handling them.
+-- The name is because a sink is needed to consume the locally produced stream.
+--
+-- This can be thought of as a writer capability of a list of values @HasWriter
+-- tag [v]@ with @\\x -> tell \@tag [x]@ as a primitive operation. However, that
+-- implementation would be inefficient.
+--
+-- For example using the 'Streaming.Prelude.Stream' instance, a producer defined
+-- using this capability can be consumed efficiently in a streaming fashion.
+
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE PolyKinds #-}
+
+module Capability.Sink
+  ( -- * Interface
+    module Capability.Sink.Internal.Class
+    -- * Strategies
+  , module Capability.Sink.Internal.Strategies
+    -- ** Modifiers
+  , module Capability.Accessors
+    -- * Helpers
+  , module Capability.Constraints
+  , module Capability.TypeOf
+  , HasSink'
+  ) where
+
+import Capability.Sink.Internal.Class
+import Capability.Sink.Internal.Strategies
+import Capability.Accessors
+import Capability.Constraints
+import Capability.TypeOf
+
+-- | Type synonym using the 'TypeOf' type family to specify 'HasSink'
+-- constraints without having to specify the type associated to a tag.
+type HasSink' (tag :: k) = HasSink tag (TypeOf k tag)

--- a/src/Capability/Sink/Internal/Class.hs
+++ b/src/Capability/Sink/Internal/Class.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeInType #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+{-# OPTIONS_HADDOCK hide #-}
+
+module Capability.Sink.Internal.Class where
+
+import GHC.Exts (Proxy#, proxy#)
+
+-- | Sinking capability.
+--
+-- An instance does not need to fulfill any additional laws
+-- besides the monad laws.
+class Monad m
+  => HasSink (tag :: k) (a :: *) (m :: * -> *) | tag m -> a
+  where
+    -- | For technical reasons, this method needs an extra proxy argument.
+    -- You only need it if you are defining new instances of 'HasSink'.
+    -- Otherwise, you will want to use 'yield'.
+    -- See 'yield' for more documentation.
+    yield_ :: Proxy# tag -> a -> m ()
+
+-- | @yield \@tag a@
+-- emits @a@ in the sink capability @tag@.
+yield :: forall tag a m. HasSink tag a m => a -> m ()
+yield = yield_ (proxy# @_ @tag)
+{-# INLINE yield #-}

--- a/src/Capability/Sink/Internal/Strategies.hs
+++ b/src/Capability/Sink/Internal/Strategies.hs
@@ -1,0 +1,175 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeInType #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+{-# OPTIONS_HADDOCK hide #-}
+
+module Capability.Sink.Internal.Strategies
+  ( SinkStack(..)
+  , SinkDList(..)
+  , SinkLog(..)
+  ) where
+
+import Capability.Accessors
+import Capability.Source.Internal.Class
+import Capability.Sink.Internal.Class
+import Capability.State.Internal.Class
+import Capability.State.Internal.Strategies.Common
+import Control.Lens (set)
+import Control.Monad.IO.Class (MonadIO)
+import Control.Monad.Primitive (PrimMonad)
+import qualified Control.Monad.State.Class as State
+import Control.Monad.Trans.Class (MonadTrans, lift)
+import Data.Coerce (Coercible, coerce)
+import Data.DList (DList)
+import qualified Data.DList as DList
+import qualified Data.Generics.Product.Fields as Generic
+import qualified Data.Generics.Product.Positions as Generic
+import Data.IORef
+import Data.Mutable
+import Streaming
+import qualified Streaming.Prelude as S
+
+-- | Accumulate sunk values in a reverse order list.
+newtype SinkStack m (a :: *) = SinkStack (m a)
+  deriving (Functor, Applicative, Monad, MonadIO, PrimMonad)
+instance HasState tag [a] m => HasSink tag a (SinkStack m) where
+  yield_ _ a = coerce @(m ()) $ modify' @tag (a:)
+  {-# INLINE yield_ #-}
+
+-- | Accumulate sunk values in forward order in a difference list.
+newtype SinkDList m (a :: *) = SinkDList (m a)
+  deriving (Functor, Applicative, Monad, MonadIO, PrimMonad)
+-- | This instance may seem a bit odd at first. All it does is wrap each
+-- 'yield'ed value in a single element difference list. How does re-yielding
+-- something else constitute a strategy for implementing 'HasSink' in the
+-- first place? The answer is that difference lists form a monoid, which allows
+-- a second stragegy to be used which accumulates all 'yield's in a single
+-- value, actually eliminating the 'HasSink' constraint this time.
+--
+-- 'SinkLog' below in fact does this, so the easiest way to fully eliminate
+-- the 'HasSink' constraint as described above is:
+--
+-- > deriving (HasSink tag w) via
+-- >   SinkDList (SinkLog (MonadState SomeStateMonad))
+instance HasSink tag (DList a) m => HasSink tag a (SinkDList m) where
+  yield_ _ = coerce @(a -> m ()) $ yield @tag . DList.singleton
+  {-# INLINE yield_ #-}
+
+-- | Accumulate sunk values with their own monoid.
+newtype SinkLog m (a :: *) = SinkLog (m a)
+  deriving (Functor, Applicative, Monad, MonadIO, PrimMonad)
+instance (Monoid w, HasState tag w m) => HasSink tag w (SinkLog m) where
+    yield_ _ w = coerce @(m ()) $ modify' @tag (<> w)
+    {-# INLINE yield_ #-}
+
+instance Monad m => HasSink tag a (S.Stream (Of a) m) where
+  yield_ _ = S.yield
+  {-# INLINE yield_ #-}
+
+-- | Lift one layer in a monad transformer stack.
+--
+-- Note, that if the 'HasSink' instance is based on 'HasState', then it is
+-- more efficient to apply 'Lift' to the underlying state capability. E.g.
+-- you should favour
+--
+-- > deriving (HasSink tag w) via
+-- >   SinkLog (Lift (SomeTrans (MonadState SomeStateMonad)))
+--
+-- over
+--
+-- > deriving (HasSink tag w) via
+-- >   Lift (SomeTrans (SinkLog (MonadState SomeStateMonad)))
+instance (HasSink tag a m, MonadTrans t, Monad (t m))
+  => HasSink tag a (Lift (t m))
+  where
+    yield_ _ = coerce @(a -> t m ()) $ lift . yield @tag
+    {-# INLINE yield_ #-}
+
+-- | Compose two accessors.
+deriving via ((t2 :: (* -> *) -> * -> *) ((t1 :: (* -> *) -> * -> *) m))
+  instance
+  ( forall x. Coercible (m x) (t2 (t1 m) x)
+  , Monad m, HasSink tag a (t2 (t1 m)) )
+  => HasSink tag a ((t2 :.: t1) m)
+
+-- | Convert the state using safe coercion.
+instance
+  ( Coercible from to, HasSink tag from m
+  , forall x y. Coercible x y => Coercible (m x) (m y) )
+  => HasSink tag to (Coerce to m)
+  where
+    yield_ tag = coerce @(from -> m ()) $ yield_ tag
+    {-# INLINE yield_ #-}
+
+-- | Rename the tag.
+instance HasSink oldtag s m => HasSink newtag s (Rename oldtag m) where
+  yield_ _ = coerce @(s -> m ()) $ yield @oldtag
+  {-# INLINE yield_ #-}
+
+-- | Zoom in on the record field @field@ of type @v@ in the state @record@.
+instance
+  -- The constraint raises @-Wsimplifiable-class-constraints@.
+  -- This could be avoided by instead placing @HasField'@s constraints here.
+  -- Unfortunately, it uses non-exported symbols from @generic-lens@.
+  ( tag ~ field, Generic.HasField' field record v, HasState oldtag record m )
+  => HasSink tag v (Field field oldtag m)
+  where
+    yield_ _ = coerce @(v -> m ()) $
+      modify @oldtag . set (Generic.field' @field @record)
+    {-# INLINE yield_ #-}
+
+-- | Zoom in on the field at position @pos@ of type @v@ in the state @struct@.
+instance
+  -- The constraint raises @-Wsimplifiable-class-constraints@.
+  -- This could be avoided by instead placing @HasPosition'@s constraints here.
+  -- Unfortunately, it uses non-exported symbols from @generic-lens@.
+  ( tag ~ pos, Generic.HasPosition' pos struct v, HasState oldtag struct m )
+  => HasSink tag v (Pos pos oldtag m)
+  where
+    yield_ _ = coerce @(v -> m ()) $
+      modify @oldtag . set (Generic.position' @pos @struct)
+    {-# INLINE yield_ #-}
+
+--------------------------------------------------------------------------------
+
+instance State.MonadState s m => HasSink tag s (MonadState m) where
+  yield_ _ = coerce @(s -> m ()) State.put
+  {-# INLINE yield_ #-}
+
+instance
+  (HasSource tag (IORef s) m, MonadIO m)
+  => HasSink tag s (ReaderIORef m)
+  where
+    yield_ _ v = ReaderIORef $ do
+      ref <- await @tag
+      liftIO $ writeIORef ref v
+    {-# INLINE yield_ #-}
+
+instance
+  ( MutableRef ref, RefElement ref ~ s
+  , HasSource tag ref m, PrimMonad m, PrimState m ~ MCState ref )
+  => HasSink tag s (ReaderRef m)
+  where
+    yield_ _ v = ReaderRef $ do
+      ref <- await @tag
+      writeRef ref v
+    {-# INLINE yield_ #-}

--- a/src/Capability/Source.hs
+++ b/src/Capability/Source.hs
@@ -1,0 +1,55 @@
+-- | Defines a capability for computations that consume a stream of values
+-- as part of their execution.
+--
+-- Programs comsuming streams of data are common. Examples: rolling up input
+-- events. Sources are similar to Python generators.
+--
+-- This can be thought of as a reader capability where there's no guarantee that
+-- one reads the same value each time.
+--
+-- The 'HasSource' capability enables separating the logic responsible for
+-- emitting events from that responsible for collecting or handling them.
+-- The name is because a source is needed to produce the locally consumed stream.
+--
+
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeInType #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Capability.Source
+  ( -- * Interface
+    module Capability.Source.Internal.Class
+    -- * Strategies
+  , module Capability.Source.Internal.Strategies
+    -- ** Modifiers
+  , module Capability.Accessors
+    -- * Helpers
+  , module Capability.Constraints
+  , module Capability.TypeOf
+  , HasSource'
+  ) where
+
+import Capability.Accessors
+import Capability.Constraints
+import Capability.Source.Internal.Class
+import Capability.Source.Internal.Strategies
+import Capability.TypeOf
+
+-- | Type synonym using the 'TypeOf' type family to specify 'HasSource'
+-- constraints without having to specify the type associated to a tag.
+type HasSource' (tag :: k) = HasSource tag (TypeOf k tag)

--- a/src/Capability/Source/Internal/Class.hs
+++ b/src/Capability/Source/Internal/Class.hs
@@ -1,0 +1,66 @@
+-- | Defines a capability for computations that consume a stream of values
+-- as part of their execution.
+--
+-- Programs comsuming streams of data are common. Examples: rolling up input
+-- events. Sources are similar to Python generators.
+--
+-- This can be thought of as a reader capability where there's no guarantee that
+-- one reads the same value each time.
+--
+-- The 'HasSource' capability enables separating the logic responsible for
+-- emitting events from that responsible for collecting or handling them.
+-- The name is because a source is needed to produce the locally consumed stream.
+--
+
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeInType #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+{-# OPTIONS_HADDOCK hide #-}
+
+module Capability.Source.Internal.Class where
+
+import GHC.Exts (Proxy#, proxy#)
+
+-- | Sourcing capability.
+--
+-- An instance does not need to fulfill any additional laws
+-- besides the monad laws.
+class Monad m
+  => HasSource (tag :: k) (a :: *) (m :: * -> *) | tag m -> a
+  where
+    -- | For technical reasons, this method needs an extra proxy argument.
+    -- You only need it if you are defining new instances of 'HasSource'.
+    -- Otherwise, you will want to use 'await'.
+    -- See 'await' for more documentation.
+    await_ :: Proxy# tag -> m a
+
+-- | @await \@tag a@
+-- takes @a@ from the source capability @tag@.
+await :: forall tag a m. HasSource tag a m => m a
+await = await_ (proxy# @_ @tag)
+{-# INLINE await #-}
+
+-- | @awaits \@tag@
+-- retrieves the image by @f@ of the environment
+-- of the reader capability @tag@.
+--
+-- prop> awaits @tag f = f <$> await @tag
+awaits :: forall tag r m a. HasSource tag r m => (r -> a) -> m a
+awaits f = f <$> await @tag
+{-# INLINE awaits #-}

--- a/src/Capability/Source/Internal/Strategies.hs
+++ b/src/Capability/Source/Internal/Strategies.hs
@@ -1,0 +1,163 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeInType #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+{-# OPTIONS_HADDOCK hide #-}
+
+module Capability.Source.Internal.Strategies
+  ( MonadReader(..)
+  , ReadStatePure(..)
+  , ReadState(..)
+  , MonadState(..)
+  , ReaderIORef(..)
+  , ReaderRef(..)
+  ) where
+
+import Capability.Source.Internal.Class
+import Capability.State.Internal.Class
+import Capability.State.Internal.Strategies.Common
+import Capability.Accessors
+import Control.Lens (view)
+import Control.Monad.Catch (MonadMask)
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import Control.Monad.Primitive (PrimMonad)
+import qualified Control.Monad.Reader.Class as Reader
+import qualified Control.Monad.State.Class as State
+import Control.Monad.Trans.Class (MonadTrans, lift)
+import Data.Coerce (Coercible, coerce)
+import Data.IORef
+import Data.Mutable
+import qualified Data.Generics.Product.Fields as Generic
+import qualified Data.Generics.Product.Positions as Generic
+
+--------------------------------------------------------------------------------
+
+-- | Derive 'HasSource' from @m@'s 'Control.Monad.Reader.Class.MonadReader'
+-- instance.
+newtype MonadReader (m :: * -> *) (a :: *) = MonadReader (m a)
+  deriving (Functor, Applicative, Monad, MonadIO, PrimMonad)
+
+instance Reader.MonadReader r m => HasSource tag r (MonadReader m) where
+  await_ _ = coerce @(m r) Reader.ask
+  {-# INLINE await_ #-}
+
+-- | Convert a /pure/ state monad into a reader monad.
+--
+-- /Pure/ meaning that the monad stack does not allow catching exceptions.
+-- Otherwise, an exception occurring in the action passed to 'local' could cause
+-- the context to remain modified outside of the call to 'local'. E.g.
+--
+-- > local @tag (const r') (throw MyException)
+-- > `catch` \MyException -> ask @tag
+--
+-- returns @r'@ instead of the previous value.
+--
+-- Note, that no @MonadIO@ instance is provided, as this would allow catching
+-- exceptions.
+--
+-- See 'ReadState'.
+newtype ReadStatePure (m :: * -> *) (a :: *) = ReadStatePure (m a)
+  deriving (Functor, Applicative, Monad)
+
+instance HasState tag r m => HasSource tag r (ReadStatePure m) where
+  await_ _ = coerce @(m r) $ get @tag
+  {-# INLINE await_ #-}
+
+-- | Convert a state monad into a reader monad.
+--
+-- Use this if the monad stack allows catching exceptions.
+--
+-- See 'ReadStatePure'.
+newtype ReadState (m :: * -> *) (a :: *) = ReadState (m a)
+  deriving (Functor, Applicative, Monad, MonadIO, PrimMonad)
+
+instance
+  (HasState tag r m, MonadMask m)
+  => HasSource tag r (ReadState m)
+  where
+    await_ _ = coerce @(m r) $ get @tag
+    {-# INLINE await_ #-}
+
+instance
+  ( tag ~ pos, Generic.HasPosition' pos struct v, HasSource oldtag struct m )
+  => HasSource tag v (Pos pos oldtag m)
+  where
+    await_ _ = coerce @(m v) $
+      awaits @oldtag $ view (Generic.position' @pos)
+    {-# INLINE await_ #-}
+
+deriving via ((t2 :: (* -> *) -> * -> *) ((t1 :: (* -> *) -> * -> *) m))
+  instance
+  ( forall x. Coercible (m x) (t2 (t1 m) x)
+  , Monad m, HasSource tag r (t2 (t1 m)) )
+  => HasSource tag r ((t2 :.: t1) m)
+
+instance
+  ( Coercible from to, HasSource tag from m
+  , forall x y. Coercible x y => Coercible (m x) (m y) )
+  => HasSource tag to (Coerce to m)
+  where
+    await_ tag = coerce @(m from) $ await_ tag
+    {-# INLINE await_ #-}
+
+-- | Rename the tag.
+instance HasSource oldtag r m => HasSource newtag r (Rename oldtag m) where
+  await_ _ = coerce @(m r) $ await @oldtag
+  {-# INLINE await_ #-}
+
+instance
+  ( tag ~ field, Generic.HasField' field record v, HasSource oldtag record m )
+  => HasSource tag v (Field field oldtag m)
+  where
+    await_ _ = coerce @(m v) $
+      awaits @oldtag $ view (Generic.field' @field)
+    {-# INLINE await_ #-}
+
+instance (HasSource tag r m, MonadTrans t, Monad (t m))
+  => HasSource tag r (Lift (t m))
+  where
+    await_ _ = coerce $ lift @t @m $ await @tag @r
+    {-# INLINE await_ #-}
+
+--------------------------------------------------------------------------------
+
+instance State.MonadState s m => HasSource tag s (MonadState m) where
+  await_ _ = coerce @(m s) State.get
+  {-# INLINE await_ #-}
+
+instance
+  (HasSource tag (IORef s) m, MonadIO m)
+  => HasSource tag s (ReaderIORef m)
+  where
+    await_ _ = ReaderIORef $ do
+      ref <- await @tag
+      liftIO $ readIORef ref
+    {-# INLINE await_ #-}
+
+instance
+  ( MutableRef ref, RefElement ref ~ s
+  , HasSource tag ref m, PrimMonad m, PrimState m ~ MCState ref )
+  => HasSource tag s (ReaderRef m)
+  where
+    await_ _ = ReaderRef $ do
+      ref <- await @tag
+      readRef ref
+    {-# INLINE await_ #-}

--- a/src/Capability/State/Internal/Class.hs
+++ b/src/Capability/State/Internal/Class.hs
@@ -26,6 +26,8 @@ module Capability.State.Internal.Class
 
 import Capability.Constraints
 import Capability.Context (context)
+import Capability.Source.Internal.Class
+import Capability.Sink.Internal.Class
 import Data.Coerce (Coercible)
 import GHC.Exts (Proxy#, proxy#)
 
@@ -40,19 +42,9 @@ import GHC.Exts (Proxy#, proxy#)
 -- prop> put @t s1 >> put @t s2 = put @t s2
 -- prop> put @t s >> get @t = put @t s >> pure s
 -- prop> state @t f = get @t >>= \s -> let (a, s') = f s in put @t s' >> pure a
-class Monad m
+class (Monad m, HasSource tag s m, HasSink tag s m)
   => HasState (tag :: k) (s :: *) (m :: * -> *) | tag m -> s
   where
-    -- | For technical reasons, this method needs an extra proxy argument.
-    -- You only need it if you are defining new instances of 'HasState.
-    -- Otherwise, you will want to use 'get'.
-    -- See 'get' for more documentation.
-    get_ :: Proxy# tag -> m s
-    -- | For technical reasons, this method needs an extra proxy argument.
-    -- You only need it if you are defining new instances of 'HasState.
-    -- Otherwise, you will want to use 'put'.
-    -- See 'put' for more documentation.
-    put_ :: Proxy# tag -> s -> m ()
     -- | For technical reasons, this method needs an extra proxy argument.
     -- You only need it if you are defining new instances of 'HasState.
     -- Otherwise, you will want to use 'state'.
@@ -62,13 +54,13 @@ class Monad m
 -- | @get \@tag@
 -- retrieve the current state of the state capability @tag@.
 get :: forall tag s m. HasState tag s m => m s
-get = get_ (proxy# @_ @tag)
+get = await @tag
 {-# INLINE get #-}
 
 -- | @put \@tag s@
 -- replace the current state of the state capability @tag@ with @s@.
 put :: forall tag s m. HasState tag s m => s -> m ()
-put = put_ (proxy# @_ @tag)
+put = yield @tag
 {-# INLINE put #-}
 
 -- | @state \@tag f@

--- a/src/Capability/State/Internal/Strategies/Common.hs
+++ b/src/Capability/State/Internal/Strategies/Common.hs
@@ -1,0 +1,70 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeInType #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -Wno-simplifiable-class-constraints #-}
+
+{-# OPTIONS_HADDOCK hide #-}
+
+module Capability.State.Internal.Strategies.Common
+  ( MonadState(..)
+  , ReaderIORef(..)
+  , ReaderRef(..)
+  ) where
+
+import Control.Monad.IO.Class (MonadIO)
+import Control.Monad.Primitive (PrimMonad)
+
+-- | Derive 'HasState' from @m@'s
+-- 'Control.Monad.State.Class.MonadState' instance.
+newtype MonadState (m :: * -> *) (a :: *) = MonadState (m a)
+  deriving (Functor, Applicative, Monad, MonadIO, PrimMonad)
+
+-- | Derive a state monad from a reader over an 'Data.IORef.IORef'.
+--
+-- Example:
+--
+-- > newtype MyState m a = MyState (ReaderT (IORef Int) m a)
+-- >   deriving (Functor, Applicative, Monad)
+-- >   deriving HasState "foo" Int via
+-- >     ReaderIORef (MonadReader (ReaderT (IORef Int) m))
+--
+-- See 'ReaderRef' for a more generic strategy.
+newtype ReaderIORef m a = ReaderIORef (m a)
+  deriving (Functor, Applicative, Monad)
+
+-- | Derive a state monad from a reader over a mutable reference.
+--
+-- Mutable references are available in a 'Control.Monad.Primitive.PrimMonad'.
+-- The corresponding 'Control.Monad.Primitive.PrimState' has to match the
+-- 'Data.Mutable.MCState' of the reference. This constraint makes a stand-alone
+-- deriving clause necessary.
+--
+-- Example:
+--
+-- > newtype MyState m a = MyState (ReaderT (IORef Int) m a)
+-- >   deriving (Functor, Applicative, Monad)
+-- > deriving via ReaderRef (MonadReader (ReaderT (IORef Int) m))
+-- >   instance (PrimMonad m, PrimState m ~ PrimState IO)
+-- >   => HasState "foo" Int (MyState m)
+--
+-- See 'ReaderIORef' for a specialized version over 'Data.IORef.IORef'.
+newtype ReaderRef m (a :: *) = ReaderRef (m a)
+  deriving (Functor, Applicative, Monad, MonadIO, PrimMonad)

--- a/src/Capability/Stream.hs
+++ b/src/Capability/Stream.hs
@@ -1,146 +1,33 @@
--- | Defines a capability for computations that produce a stream of values
--- as part of their execution.
---
--- Programs producing streams of data are common. Examples: emitting events on
--- input, or emitting events whenever certain conditions are observed. Streams
--- are similar to Python generators.
---
--- The 'HasStream' capability enables separating the logic responsible for
--- emitting events from that responsible for collecting or handling them.
---
--- This can be thought of as a writer capability of a list of values @HasWriter
--- tag [v]@ with @\\x -> tell \@tag [x]@ as a primitive operation. However, that
--- implementation would be inefficient.
---
--- For example using the 'Streaming.Prelude.Stream' instance, a producer defined
--- using this capability can be consumed efficiently in a streaming fashion.
-
-{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE ConstraintKinds #-}
-{-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE FunctionalDependencies #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE MagicHash #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE QuantifiedConstraints #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeInType #-}
-{-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE UnboxedTuples #-}
-{-# LANGUAGE UndecidableInstances #-}
-
-module Capability.Stream
+{-# LANGUAGE PolyKinds #-}
+module Capability.Stream {-# DEPRECATED "Use 'Capability.Sink' "#-}
   ( -- * Interface
-    HasStream(..)
+    HasStream
   , HasStream'
   , yield
     -- * Strategies
-  , StreamStack(..)
-  , StreamDList(..)
-  , StreamLog(..)
+  , StreamStack
+  , StreamDList
+  , StreamLog
     -- ** Modifiers
   , module Capability.Accessors
   ) where
 
 import Capability.Accessors
-import Capability.State
-import Control.Monad.IO.Class (MonadIO)
-import Control.Monad.Primitive (PrimMonad)
-import Control.Monad.Trans.Class (MonadTrans, lift)
-import Data.Coerce (Coercible, coerce)
-import Data.DList (DList)
-import qualified Data.DList as DList
-import GHC.Exts (Proxy#, proxy#)
-import Streaming
-import qualified Streaming.Prelude as S
 
--- | Streaming capability.
---
--- An instance does not need to fulfill any additional laws
--- besides the monad laws.
-class Monad m
-  => HasStream (tag :: k) (a :: *) (m :: * -> *) | tag m -> a
-  where
-    -- | For technical reasons, this method needs an extra proxy argument.
-    -- You only need it if you are defining new instances of 'HasReader'.
-    -- Otherwise, you will want to use 'yield'.
-    -- See 'yield' for more documentation.
-    yield_ :: Proxy# tag -> a -> m ()
+import Capability.Sink
 
--- | @yield \@tag a@
--- emits @a@ in the stream capability @tag@.
-yield :: forall tag a m. HasStream tag a m => a -> m ()
-yield = yield_ (proxy# @_ @tag)
-{-# INLINE yield #-}
+{-# DEPRECATED HasStream "Use 'HasSink'" #-}
+type HasStream = HasSink
 
--- | Accumulate streamed values in a reverse order list.
-newtype StreamStack m (a :: *) = StreamStack (m a)
-  deriving (Functor, Applicative, Monad, MonadIO, PrimMonad)
-instance HasState tag [a] m => HasStream tag a (StreamStack m) where
-  yield_ _ a = coerce @(m ()) $ modify' @tag (a:)
-  {-# INLINE yield_ #-}
+{-# DEPRECATED StreamStack "Use 'SinkStack'" #-}
+type StreamStack = SinkStack
 
--- | Accumulate streamed values in forward order in a difference list.
-newtype StreamDList m (a :: *) = StreamDList (m a)
-  deriving (Functor, Applicative, Monad, MonadIO, PrimMonad)
--- | This instance may seem a bit odd at first. All it does is wrap each
--- 'yield'ed value in a single element difference list. How does re-yielding
--- something else constitute a strategy for implementing 'HasStream' in the
--- first place? The answer is that difference lists form a monoid, which allows
--- a second stragegy to be used which accumulates all 'yield's in a single
--- value, actually eliminating the 'HasStream' constraint this time.
---
--- 'StreamLog' below in fact does this, so the easiest way to fully eliminate
--- the 'HasStream' constraint as described above is:
---
--- > deriving (HasStream tag w) via
--- >   StreamDList (StreamLog (MonadState SomeStateMonad))
-instance HasStream tag (DList a) m => HasStream tag a (StreamDList m) where
-  yield_ _ = coerce @(a -> m ()) $ yield @tag . DList.singleton
-  {-# INLINE yield_ #-}
+{-# DEPRECATED StreamDList "Use 'SinkDList'" #-}
+type StreamDList = SinkDList
 
--- | Accumulate streamed values with their own monoid.
-newtype StreamLog m (a :: *) = StreamLog (m a)
-  deriving (Functor, Applicative, Monad, MonadIO, PrimMonad)
-instance (Monoid w, HasState tag w m) => HasStream tag w (StreamLog m) where
-    yield_ _ w = coerce @(m ()) $ modify' @tag (<> w)
-    {-# INLINE yield_ #-}
+{-# DEPRECATED StreamLog "Use 'SinkLog'" #-}
+type StreamLog = SinkLog
 
-instance Monad m => HasStream tag a (S.Stream (Of a) m) where
-  yield_ _ = S.yield
-  {-# INLINE yield_ #-}
-
--- | Lift one layer in a monad transformer stack.
---
--- Note, that if the 'HasStream' instance is based on 'HasState', then it is
--- more efficient to apply 'Lift' to the underlying state capability. E.g.
--- you should favour
---
--- > deriving (HasStream tag w) via
--- >   StreamLog (Lift (SomeTrans (MonadState SomeStateMonad)))
---
--- over
---
--- > deriving (HasStream tag w) via
--- >   Lift (SomeTrans (StreamLog (MonadState SomeStateMonad)))
-instance (HasStream tag a m, MonadTrans t, Monad (t m))
-  => HasStream tag a (Lift (t m))
-  where
-    yield_ _ = coerce @(a -> t m ()) $ lift . yield @tag
-    {-# INLINE yield_ #-}
-
--- | Compose two accessors.
-deriving via ((t2 :: (* -> *) -> * -> *) ((t1 :: (* -> *) -> * -> *) m))
-  instance
-  ( forall x. Coercible (m x) (t2 (t1 m) x)
-  , Monad m, HasStream tag a (t2 (t1 m)) )
-  => HasStream tag a ((t2 :.: t1) m)
-
--- | Type synonym using the 'TypeOf' type family to specify 'HasStream'
--- constraints without having to specify the type associated to a tag.
-type HasStream' (tag :: k) = HasStream tag (TypeOf k tag)
+{-# DEPRECATED HasStream' "Use 'HasSink''" #-}
+type HasStream' tag = HasSink' tag


### PR DESCRIPTION
We now have:

```
    Sink     Source
    /   \    /   \
   /     \  /     \
Writer   State    Reader
```

HasStream has been renamed (with deprecated aliases for compat) to HasSink, to
illustrate the symmetry.

WIP because I need to review myself, and probably also fix examples.

Fixes #63.