### PR TITLE
Use LTS resolver instead of nightly

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2018-09-29
+resolver: lts-14.7
 packages:
 - '.'
 


### PR DESCRIPTION
My guess is that the LTS version at the time did not support features required by this project. If so, that's no longer the case: now the LTS resolver can be used. That seems like a good idea to me.