### PR TITLE
Fix loop in Capability.HasWriter.writer

### DIFF
--- a/src/Capability/Writer.hs
+++ b/src/Capability/Writer.hs
@@ -117,7 +117,7 @@ class (Monoid w, Monad m, HasSink tag w m)
 -- Appends @w@ to the output of the writer capability @tag@
 -- and returns the value @a@.
 writer :: forall tag w m a. HasWriter tag w m => (a, w) -> m a
-writer = writer @tag
+writer = writer_ (proxy# @_ @tag)
 {-# INLINE writer #-}
 
 -- | @tell \@tag w@


### PR DESCRIPTION
`Capability.HasWriter.writer` was calling itself in a loop instead of calling `Capability.HasWriter.writer_`.