### PR TITLE
Implement reflection for ad-hoc interpreters

### DIFF
--- a/capability.cabal
+++ b/capability.cabal
@@ -44,6 +44,7 @@ library
     Capability.Reader
     Capability.Reader.Internal.Class
     Capability.Reader.Internal.Strategies
+    Capability.Reflection
     Capability.Sink
     Capability.Sink.Internal.Class
     Capability.Sink.Internal.Strategies
@@ -70,6 +71,7 @@ library
     , mtl >= 2.0 && < 3.0
     , mutable-containers >= 0.3 && < 0.4
     , primitive >= 0.6 && < 0.8
+    , reflection >= 2.1 && < 2.2
     , safe-exceptions >= 0.1 && < 0.2
     , streaming >= 0.2 && < 0.3
     , transformers >= 0.5.5 && < 0.6
@@ -88,6 +90,7 @@ library
 test-suite examples
   type: exitcode-stdio-1.0
   other-modules:
+    Reflection
     WordCount
     CountLog
     Error
@@ -101,6 +104,7 @@ test-suite examples
       base >= 4.12 && < 5.0
     , capability
     , containers >= 0.6 && < 0.7
+    , dlist >= 0.8 && < 0.9
     , hspec >= 2.0 && < 3.0
     , lens >= 4.16 && < 5.0
     , mtl >= 2.0 && < 3.0

--- a/examples/Reflection.hs
+++ b/examples/Reflection.hs
@@ -1,0 +1,255 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Reflection where
+
+import Capability.Error
+import Capability.Reader
+import Capability.Reflection
+import Capability.Sink
+import Capability.Source
+import Capability.State
+import Capability.Writer
+import Control.Monad (forM_, replicateM)
+import qualified Control.Monad.Except as MTL
+import qualified Control.Monad.State as MTL
+import Data.DList (DList)
+import qualified Data.DList as DList
+import Data.Monoid (Product (..))
+import Test.Hspec
+
+----------------------------------------------------------------------
+-- Instances
+
+newtype Logger s a = Logger (MTL.State (DList String, s) a)
+  deriving (Functor, Applicative, Monad)
+  deriving
+    (HasSink "log" String)
+    via SinkDList (SinkLog (Rename 1 (Pos 1 () (MonadState (MTL.State (DList String, s))))))
+  deriving
+    (HasState "test" s, HasSource "test" s, HasSink "test" s)
+    via Rename 2 (Pos 2 () (MonadState (MTL.State (DList String, s))))
+
+runLogger :: s -> Logger s a -> (a, s, [String])
+runLogger s0 (Logger m) =
+  case MTL.runState m (mempty, s0) of
+    (a, (log', s)) -> (a, s, DList.toList log')
+
+----------------------------------------------------------------------
+-- Test Cases
+
+spec :: Spec
+spec = do
+  describe "interpret_" $ do
+    it "evaluates HasSource" $ do
+      runLogger
+        [1, 2, 3 :: Int]
+        ( interpret_ @"source"
+            ReifiedSource
+              { _await = do
+                  yield @"log" "await"
+                  state @"test" $ \case
+                    (x : xs) -> (x, xs)
+                    [] -> error "empty stream"
+              }
+            (replicateM 3 $ await @"source")
+        )
+        `shouldBe` ([1, 2, 3], [], ["await", "await", "await"])
+    it "evaluates HasSink" $ do
+      runLogger
+        []
+        ( interpret_ @"sink"
+            ReifiedSink
+              { _yield = \x -> do
+                  yield @"log" "yield"
+                  modify @"test" (x :)
+              }
+            (forM_ [1, 2, 3 :: Int] $ yield @"sink")
+        )
+        `shouldBe` ((), [3, 2, 1], ["yield", "yield", "yield"])
+    it "evaluates HasReader" $ do
+      runLogger
+        (42 :: Int)
+        ( interpret_ @"reader"
+            ReifiedReader
+              { _readerSource =
+                  ReifiedSource
+                    { _await = do
+                        yield @"log" "ask"
+                        get @"test"
+                    },
+                _local = \f m -> do
+                  yield @"log" "local"
+                  r <- state @"test" $ \r -> (r, f r)
+                  a <- m
+                  put @"test" r
+                  pure a,
+                _reader = \f -> do
+                  yield @"log" "reader"
+                  f <$> get @"test"
+              }
+            ( sequence
+                [ ask @"reader",
+                  local @"reader" succ $ do
+                    asks @"reader" succ,
+                  reader @"reader" pred
+                ]
+            )
+        )
+        `shouldBe` ([42, 44, 41], 42, ["ask", "local", "ask", "reader"])
+    it "evaluates HasState" $ do
+      runLogger
+        (42 :: Int)
+        ( interpret_ @"state"
+            ReifiedState
+              { _stateSource =
+                  ReifiedSource
+                    { _await = do
+                        yield @"log" "get"
+                        get @"test"
+                    },
+                _stateSink =
+                  ReifiedSink
+                    { _yield = \x -> do
+                        yield @"log" "put"
+                        put @"test" x
+                    },
+                _state = \f -> do
+                  yield @"log" "state"
+                  state @"test" f
+              }
+            ( do
+                old <- get @"state"
+                put @"state" 0
+                state @"state" (\new -> (old, succ new))
+            )
+        )
+        `shouldBe` (42, 1, ["get", "put", "state"])
+    it "evaluates HasWriter" $ do
+      runLogger
+        (mempty :: Product Int)
+        ( interpret_ @"writer"
+            ReifiedWriter
+              { _writerSink =
+                  ReifiedSink
+                    { _yield = \w -> do
+                        yield @"log" "tell"
+                        modify @"test" (<> w)
+                    },
+                _writer = \(a, w) -> do
+                  yield @"log" "writer"
+                  modify @"test" (<> w)
+                  pure a,
+                _listen = \m -> do
+                  yield @"log" "listen"
+                  w0 <- state @"test" $ \s -> (s, mempty)
+                  a <- m
+                  w <- state @"test" $ \s -> (s, w0 <> s)
+                  pure (a, w),
+                _pass = \m -> do
+                  yield @"log" "pass"
+                  w0 <- state @"test" $ \s -> (s, mempty)
+                  (a, f) <- m
+                  modify' @"test" $ \s -> w0 <> f s
+                  pure a
+              }
+            ( do
+                tell @"writer" 2
+                writer @"writer" ((), 3)
+                ((), w) <- listen @"writer" $ do
+                  tell @"writer" 5
+                pass @"writer" $ do
+                  tell @"writer" 6
+                  pure ((), (+ 1))
+                pure w
+            )
+        )
+        `shouldBe` (5, 2 * 3 * 5 * 7, ["tell", "writer", "listen", "tell", "pass", "tell"])
+    it "evaluates HasThrow" $ do
+      runLogger
+        ()
+        ( MTL.runExceptT $
+            interpret_ @"throw"
+              ReifiedThrow
+                { _throw = \e -> do
+                    MTL.lift $ yield @"log" "throw"
+                    MTL.throwError e
+                }
+              ( do
+                  _ <- throw @"throw" "some error"
+                  pure $! tail ""
+              )
+        )
+        `shouldBe` (Left "some error", (), ["throw"])
+    it "evaluates HasCatch" $ do
+      runLogger
+        ()
+        ( MTL.runExceptT $
+            interpret_ @"catch"
+              ReifiedCatch
+                { _catchThrow =
+                    ReifiedThrow
+                      { _throw = \e -> do
+                          MTL.lift $ yield @"log" "throw"
+                          MTL.throwError e
+                      },
+                  _catch = \m h -> do
+                    MTL.lift $ yield @"log" "catch"
+                    MTL.catchError m h,
+                  _catchJust = \f m h -> do
+                    MTL.lift $ yield @"log" "catchJust"
+                    MTL.catchError m $ \e ->
+                      case f e of
+                        Just b -> h b
+                        Nothing -> MTL.throwError e
+                }
+              ( do
+                  e1 <-
+                    catch @"catch"
+                      ( do
+                          _ <- throw @"catch" "some error"
+                          pure $! tail ""
+                      )
+                      pure
+                  catchJust @"catch"
+                    (const Nothing)
+                    ( do
+                        _ <- throw @"catch" ("again " ++ e1)
+                        pure $! tail ""
+                    )
+                    pure
+              )
+        )
+        `shouldBe` (Left "again some error", (), ["catch", "throw", "catchJust", "throw"])
+  describe "interpret" $ do
+    it "can be nested" $ do
+      runLogger
+        ()
+        ( interpret @"source" @'[HasSink "log" String]
+            ReifiedSource
+              { _await = do
+                  yield @"log" "await"
+                  pure ()
+              }
+            ( interpret @"sink" @'[HasSink "log" String, HasSource "source" ()]
+                ReifiedSink
+                  { _yield = \() -> do
+                      yield @"log" "yield"
+                      pure ()
+                  }
+                ( do
+                    yield @"log" "begin"
+                    await @"source"
+                    yield @"sink" ()
+                    yield @"log" "end"
+                )
+            )
+        )
+        `shouldBe` ((), (), ["begin", "await", "yield", "end"])

--- a/examples/Test.hs
+++ b/examples/Test.hs
@@ -14,6 +14,7 @@ import Test.Hspec.Formatters.Jenkins (xmlFormatter)
 import qualified CountLog
 import qualified Error
 import qualified Reader
+import qualified Reflection
 import qualified State
 import qualified Sink
 import qualified Writer
@@ -25,6 +26,7 @@ spec = do
   describe "CountLog" CountLog.spec
   describe "Error" Error.spec
   describe "Reader" Reader.spec
+  describe "Reflection" Reflection.spec
   describe "State" State.spec
   describe "Sink" Sink.spec
   describe "Writer" Writer.spec

--- a/src/Capability.hs
+++ b/src/Capability.hs
@@ -108,14 +108,18 @@
 -- combinators which you can use if you absolutely must: they are correct, but
 -- inefficient, so we recommend that you do not.
 --
--- Finally there is
+-- Finally there are
 --
 -- * "Capability.Derive"
---
 -- Which exports a (still experimental) 'Capability.Derive.derive' function,
 -- which lets you run a computation which requires capabilities which are not
 -- directly provided by the ambient monad, but can be derived from the
 -- capabilities provided by the ambient monad.
+-- * "Capability.Reflection"
+-- Which exports 'Capability.Reflection.interpret_' and
+-- 'Capability.Reflection.interpret', which let you define an ad-hoc
+-- interpretation of a capability based on the capabilities provided by the
+-- ambient monad.
 --
 -- == Further considerations
 --

--- a/src/Capability/Reflection.hs
+++ b/src/Capability/Reflection.hs
@@ -1,0 +1,170 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+-- | This module allows to provide an ad-hoc interpreter for a capability using
+-- type class reflection.
+--
+-- Use the functions 'interpret_' or 'interpret' for ad-hoc interpretation of
+-- capabilities.
+--
+-- Refer to 'Reflected' if you would like to enable reflection for a new
+-- capability.
+--
+-- More complex examples using this module can be found in the
+-- [Reflection example
+-- module](https://github.com/tweag/capability/blob/master/examples/Reflection.hs).
+--
+-- For details on reflection refer to the tutorial at
+-- <https://www.tweag.io/posts/2017-12-21-reflection-tutorial.html> and the
+-- @reflection@ library at <https://hackage.haskell.org/package/reflection>.
+
+module Capability.Reflection
+  ( -- * Reflection
+    interpret_
+  , interpret
+  , Reified
+  , Reflected (..)
+  , reified
+    -- * Re-exported
+  , Reifies
+  , reify
+  , reflect
+  , Proxy (..)
+  ) where
+
+import Capability.Constraints
+import Capability.Derive
+import Data.Proxy
+import Data.Reflection
+
+-- | @interpret_ \@tag dict action@
+--
+-- Execute @action@ using the ad-hoc interpretation of a capability @c@ under
+-- @tag@ defined by @dict@, where @dict@ is a value of type @'Reified' tag c@,
+-- i.e. a record providing the implementation of the methods of capability @c@.
+--
+-- For example, the following provides an ad-hoc interpretation for the
+-- 'Capability.Source.HasSource' capability.
+--
+-- >>> :{
+--   interpret_ @"my-source"
+--     ReifiedSource { _await = pure "capabilities" }
+--     (replicateM 3 (await @"my-source"))
+--   :}
+-- ["capabilities", "capabilities", "capabilities"]
+interpret_ ::
+  forall tag c m a.
+  ( Monad m,
+    forall s. Reifies s (Reified tag c m) => c (Reflected s c m)
+  ) =>
+  Reified tag c m ->
+  (forall m'. c m' => m' a) ->
+  m a
+interpret_ = interpret @tag @'[] @c
+{-# INLINE interpret_ #-}
+
+-- | @interpret \@tag \@ambient dict action@
+--
+-- Like 'interpret_' but allows to forward the ambient capabilities @ambient@
+-- into the context of @action@ as well.
+--
+-- For example, the following provides an ad-hoc interpretation for the
+-- 'Capability.Source.HasSource' capability, while using an ambient
+-- 'Capability.Sink.HasSink' capability.
+--
+-- >>> :{
+--   interpret @"my-source" @'[HasSink "my-sink" String]
+--     ReifiedSource { _await = pure "capabilities" }
+--     (replicateM_ 3 (await @"my-source" >>= yield @"my-sink"))
+--   :}
+interpret ::
+  forall tag (cs :: [Capability]) c m a.
+  ( Monad m,
+    All cs m,
+    forall s. Reifies s (Reified tag c m) => c (Reflected s c m)
+  ) =>
+  Reified tag c m ->
+  (forall m'. All (c ': cs) m' => m' a) ->
+  m a
+interpret dict action =
+  reify dict $ \(_ :: Proxy s) ->
+    derive @(Reflected s c) @'[c] @cs action
+{-# INLINE interpret #-}
+
+-- | @Reified tag capability m@
+--
+-- Defines the dictionary type for the methods of @capability@ under @tag@ in
+-- the monad @m@. Refer to 'interpret_' for an example use-case.
+--
+-- For example, the 'Capability.Sink.HasSink' capability has the method
+-- @'Capability.Sink.yield' :: a -> m ()@. The corresponding dictionary type is
+-- defined as follows.
+--
+-- >>> :{
+--   data instance Reified tag (HasSink tag a) m =
+--     ReifiedSink { _yield :: forall a. a -> m () }
+--   :}
+--
+-- Superclass dictionaries are represented as nested records. For example, the
+-- 'Capability.State.HasState' capability has the superclasses
+-- 'Capability.Source.HasSource' and 'Capability.Sink.HasSink' and the method
+-- @'Capability.State.state' :: (s -> (a, s)) -> m a@. The corresponding
+-- dictionary type is defined as follows.
+--
+-- >>> :{
+--   data instance Reified tag (HasState tag s) m =
+--     ReifiedState
+--       { _stateSource :: Reified tag (HasSource tag s) m,
+--         _stateSink :: Reified tag (HasSink tag s) m,
+--         _state :: forall a. (s -> (a, s)) -> m a
+--       }
+--   :}
+data family Reified (tag :: k) (c :: Capability) (m :: * -> *)
+
+-- | @Reflected s capability m@
+--
+-- Carries the type class instance for @capability@ in the monad @m@ defined by
+-- the dictionary reflected in @s@ in the type system.
+--
+-- For most use-cases it is not necessary to use this type directly. Use
+-- 'interpret_' or 'interpret' instead.
+--
+-- If you wish to enable reflection for a new capability, then you will need to
+-- define a type class instance for @Reflected@ for the new capability. Note,
+-- you will also need to define an instance of 'Reified' which defines the
+-- dictionary type of the new capability. Hint, you can use @'reified' \@s@ to
+-- obtain the dictionary from the context in the instance implementation.
+--
+-- For example, the @Reflected@ instance for the 'Capability.Sink.HasSink'
+-- capability can be defined as follows. Assuming the dictionary described in
+-- 'Reified'.
+--
+-- >>> :{
+--   instance
+--     (Monad m, Reifies s (Reified tag (HasSink tag a) m)) =>
+--     HasSink tag a (Reflected s (HasSink tag a) m)
+--     where
+--     yield a = Reflect $ _yield (reified @s) a
+--   :}
+newtype Reflected (s :: *) (c :: Capability) (m :: * -> *) (a :: *) = Reflect (m a)
+  deriving (Functor, Applicative, Monad)
+
+-- | @reified \@s@
+--
+-- Obtain the dictionary that is reflected in the type system under @s@.
+--
+-- This is a convenience wrapper around 'Data.Reflection.reflect'.
+reified :: forall s tag c m. Reifies s (Reified tag c m) => Reified tag c m
+reified = reflect (Proxy @s)
+{-# INLINE reified #-}

--- a/src/Capability/Reflection.hs
+++ b/src/Capability/Reflection.hs
@@ -12,7 +12,7 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 
--- | This module allows to provide an ad-hoc interpreter for a capability using
+-- | Use this module to provide an ad-hoc interpreter for a capability using
 -- type class reflection.
 --
 -- Use the functions 'interpret_' or 'interpret' for ad-hoc interpretation of
@@ -76,8 +76,8 @@ interpret_ = interpret @tag @'[] @c
 
 -- | @interpret \@tag \@ambient dict action@
 --
--- Like 'interpret_' but allows to forward the ambient capabilities @ambient@
--- into the context of @action@ as well.
+-- Like 'interpret_' but forwards the ambient capabilities @ambient@ into the
+-- context of @action@ as well.
 --
 -- For example, the following provides an ad-hoc interpretation for the
 -- 'Capability.Source.HasSource' capability, while using an ambient


### PR DESCRIPTION
Allows users to define ad-hoc interpretations of capabilities using the functions `Capability.Reflection.interpret_` and `Capability.Reflection.interpret` by providing a dictionary, i.e. a record of functions, that defines an implementation of the capability.

The details are explained in the Haddock documentation of `Capability.Reflection`. A reference to the top-level `Capability` Haddock documentation is added as well.

Examples are defined in `examples/Reflection.hs`.