### PR TITLE
Fix the visible type arguments of proxy#

### DIFF
--- a/capability.cabal
+++ b/capability.cabal
@@ -60,11 +60,11 @@ library
     Capability.Writer
     Capability.Writer.Discouraged
   build-depends:
-      base >= 4.12 && < 5.0
-    , constraints >= 0.1 && < 0.12
+      base >= 4.14 && < 5.0
+    , constraints >= 0.1 && < 0.13
     , dlist >= 0.8 && < 0.9
     , exceptions >= 0.6 && < 0.11
-    , generic-lens >= 1.0 && < 1.3
+    , generic-lens >= 2.0 && < 2.1
     , lens >= 4.16 && < 5.0
     , monad-control >= 1.0 && < 1.1
     , monad-unlift >= 0.2 && < 0.3
@@ -76,7 +76,7 @@ library
     , streaming >= 0.2 && < 0.3
     , transformers >= 0.5.5 && < 0.6
     , unliftio >= 0.2 && < 0.3
-    , unliftio-core >= 0.1 && < 0.2
+    , unliftio-core >= 0.1 && < 0.3
   if flag(dev)
     ghc-options: -Wall -Werror -Wcompat
                  -Wincomplete-record-updates
@@ -101,18 +101,18 @@ test-suite examples
     Writer
   main-is: Test.hs
   build-depends:
-      base >= 4.12 && < 5.0
+      base >= 4.14 && < 5.0
     , capability
-    , containers >= 0.6 && < 0.7
-    , dlist >= 0.8 && < 0.9
-    , hspec >= 2.0 && < 3.0
-    , lens >= 4.16 && < 5.0
-    , mtl >= 2.0 && < 3.0
-    , silently >= 1.2 && < 1.3
-    , streaming >= 0.2 && < 0.3
-    , temporary >= 1.0 && < 1.4
-    , text >= 0.2 && < 1.3
-    , unliftio >= 0.2 && < 0.3
+    , containers
+    , dlist
+    , hspec
+    , lens
+    , mtl
+    , silently
+    , streaming
+    , temporary
+    , text
+    , unliftio
   if flag(hspec-jenkins)
     build-depends: hspec-jenkins
   if flag(dev)

--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,7 @@
 { pkgs ? (import ./nix/nixpkgs) }:
 
 let
-  compiler = "ghc865";
+  compiler = "ghc8104";
   source = pkgs.lib.sourceByRegex ./. [
     "^.*\.md$"
     "^capability\.cabal$"

--- a/examples/CountLog.hs
+++ b/examples/CountLog.hs
@@ -22,6 +22,7 @@ import Control.Monad.State.Strict (State, StateT (..), runState)
 import qualified Data.Char
 import Data.Coerce (coerce)
 import Data.IORef
+import Data.Kind (Type)
 import GHC.Generics (Generic)
 import Test.Common
 import Test.Hspec
@@ -63,7 +64,7 @@ loudLogger = LogCtx { logger = putStrLn . map Data.Char.toUpper }
 
 
 -- | Deriving @HasReader@ from @MonadReader@.
-newtype LogM m (a :: *) = LogM (ReaderT LogCtx m a)
+newtype LogM m (a :: Type) = LogM (ReaderT LogCtx m a)
   deriving (Functor, Applicative, Monad)
   deriving Logger via
     (TheLoggerReader (Field "logger" ()
@@ -110,7 +111,7 @@ runCounterM (CounterM m) = runState m 0
 -- ReaderT IORef instance --------------------------------------------
 
 -- | Deriving @HasState@ from @HasReader@ of an @IORef@.
-newtype Counter'M m (a :: *) = Counter'M (ReaderT (IORef Int) m a)
+newtype Counter'M m (a :: Type) = Counter'M (ReaderT (IORef Int) m a)
   deriving (Functor, Applicative, Monad)
   deriving Counter via
     TheCounterState (ReaderIORef (MonadReader (ReaderT (IORef Int) m)))
@@ -139,7 +140,7 @@ data CountLogCtx = CountLogCtx
 
 
 -- | Deriving two capabilities from the record fields of @MonadReader@.
-newtype CountLogM m (a :: *) = CountLogM (ReaderT CountLogCtx m a)
+newtype CountLogM m (a :: Type) = CountLogM (ReaderT CountLogCtx m a)
   deriving (Functor, Applicative, Monad)
   deriving Counter via
     TheCounterState (ReaderIORef (Rename "countCtx" (Field "countCtx" ()

--- a/examples/Error.hs
+++ b/examples/Error.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeInType #-}

--- a/examples/Reader.hs
+++ b/examples/Reader.hs
@@ -14,6 +14,7 @@ import Capability.Reader
 import Capability.Source
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.Reader (ReaderT (..))
+import Data.Kind (Type)
 import GHC.Generics (Generic)
 import Test.Common
 import Test.Hspec
@@ -21,8 +22,8 @@ import Test.Hspec
 data Foo
 data Bar
 
-type instance TypeOf * Foo = Int
-type instance TypeOf * Bar = Int
+type instance TypeOf Type Foo = Int
+type instance TypeOf Type Bar = Int
 
 ----------------------------------------------------------------------
 -- Example Programs
@@ -65,7 +66,7 @@ fooBarMagnify = do
 -- Instances
 
 -- | @HasReader@ instance derived via @MonadReader@.
-newtype FooReaderT m (a :: *) = FooReaderT (ReaderT Int m a)
+newtype FooReaderT m (a :: Type) = FooReaderT (ReaderT Int m a)
   deriving (Functor, Applicative, Monad, MonadIO)
   deriving (HasSource Foo Int) via MonadReader (ReaderT Int m)
   deriving (HasReader Foo Int) via MonadReader (ReaderT Int m)

--- a/nix/nixpkgs/default.nix
+++ b/nix/nixpkgs/default.nix
@@ -1,6 +1,6 @@
 let
-  rev = "19.09";
-  sha256 = "0mhqhq21y5vrr1f30qd2bvydv4bbbslvyzclhw0kdxmkgg3z4c92";
+  rev = "f5f6dc053b1a0eca03c853dad710f3de070df24e";
+  sha256 = "0kxp8fmcdw2nla5kficm7ffbllczwh7b7nqagwr4djs417rf4wma";
   nixpkgs = builtins.fetchTarball {
     url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
     inherit sha256;

--- a/src/Capability/Accessors.hs
+++ b/src/Capability/Accessors.hs
@@ -20,6 +20,7 @@ module Capability.Accessors
 
 import Control.Monad.IO.Class (MonadIO)
 import Control.Monad.Primitive (PrimMonad)
+import Data.Kind (Type)
 import GHC.TypeLits (Nat, Symbol)
 
 -- | Coerce the type in the context @m@ to @to@.
@@ -37,7 +38,7 @@ import GHC.TypeLits (Nat, Symbol)
 -- @'Capability.Reader.MonadReader' (Reader Int)@ to a
 -- @'Capability.Reader.HasReader' \"a\" MyInt@
 -- instance using @Coercible Int MyInt@.
-newtype Coerce (to :: *) m (a :: *) = Coerce (m a)
+newtype Coerce (to :: Type) m (a :: Type) = Coerce (m a)
   deriving (Functor, Applicative, Monad, MonadIO, PrimMonad)
 
 -- | Rename the tag.
@@ -58,7 +59,7 @@ newtype Coerce (to :: *) m (a :: *) = Coerce (m a)
 -- and @Rename@ is redundant in this example.
 --
 -- See 'Pos' below for a common use-case.
-newtype Rename (oldtag :: k) m (a :: *) = Rename (m a)
+newtype Rename (oldtag :: k) m (a :: Type) = Rename (m a)
   deriving (Functor, Applicative, Monad, MonadIO, PrimMonad)
 
 -- | Access the record field @field@ in the context @m@.
@@ -78,7 +79,7 @@ newtype Rename (oldtag :: k) m (a :: *) = Rename (m a)
 -- instance by focusing on the field @foo@ in the @Foo@ record.
 --
 -- See 'Rename' for a way to change the tag.
-newtype Field (field :: Symbol) (oldtag :: k) m (a :: *) = Field (m a)
+newtype Field (field :: Symbol) (oldtag :: k) m (a :: Type) = Field (m a)
   deriving (Functor, Applicative, Monad, MonadIO, PrimMonad)
 
 -- | Access the value at position @pos@ in the context @m@.
@@ -104,7 +105,7 @@ newtype Field (field :: Symbol) (oldtag :: k) m (a :: *) = Field (m a)
 --   deriving (HasReader "foo" Int) via
 --     Rename 1 (Pos 1 () (MonadReader (Reader (Int, Bool))))
 -- @
-newtype Pos (pos :: Nat) (oldtag :: k) m (a :: *) = Pos (m a)
+newtype Pos (pos :: Nat) (oldtag :: k) m (a :: Type) = Pos (m a)
   deriving (Functor, Applicative, Monad, MonadIO, PrimMonad)
 
 -- | Choose the given constructor in the sum-type in context @m@.
@@ -122,7 +123,7 @@ newtype Pos (pos :: Nat) (oldtag :: k) m (a :: *) = Pos (m a)
 -- @'Capability.Error.MonadError' (ExceptT MyError Identity)@ to a
 -- @'Capability.Error.HasThrow' \"ErrB\" String@
 -- instance by wrapping thrown @String@s in the @ErrB@ constructor.
-newtype Ctor (ctor :: Symbol) (oldtag :: k) m (a :: *) = Ctor (m a)
+newtype Ctor (ctor :: Symbol) (oldtag :: k) m (a :: Type) = Ctor (m a)
   deriving (Functor, Applicative, Monad, MonadIO, PrimMonad)
 
 -- | Skip one level in a monad transformer stack.
@@ -143,7 +144,7 @@ newtype Ctor (ctor :: Symbol) (oldtag :: k) m (a :: *) = Ctor (m a)
 -- the @'Capability.State.HasState' "\foo\" Bool@ instance of the underlying
 -- @'Capability.State.MonadState' (State Bool)@ over the
 -- @StateT Int@ monad transformer.
-newtype Lift m (a :: *) = Lift (m a)
+newtype Lift m (a :: Type) = Lift (m a)
   deriving (Functor, Applicative, Monad, MonadIO, PrimMonad)
 
 
@@ -152,10 +153,10 @@ newtype Lift m (a :: *) = Lift (m a)
 -- This is not necessary in deriving via clauses, but in places where a
 -- transformer is expected as a type argument. E.g. 'HasError.wrapError'.
 newtype (:.:)
-  (t2 :: (* -> *) -> * -> *)
-  (t1 :: (* -> *) -> * -> *)
-  (m :: * -> *)
-  (a :: *)
+  (t2 :: (Type -> Type) -> Type -> Type)
+  (t1 :: (Type -> Type) -> Type -> Type)
+  (m :: Type -> Type)
+  (a :: Type)
   = (:.:) (m a)
   deriving (Functor, Applicative, Monad, MonadIO, PrimMonad)
 infixr 9 :.:

--- a/src/Capability/Constraints.hs
+++ b/src/Capability/Constraints.hs
@@ -16,12 +16,12 @@ module Capability.Constraints
   ) where
 
 import Data.Constraint (Dict(..))
-import Data.Kind (Constraint)
+import Data.Kind (Constraint, Type)
 
--- | A 'Capability' takes a type constructor @* -> *@ (e.g., a monad) and
+-- | A 'Capability' takes a type constructor @Type -> Type@ (e.g., a monad) and
 -- returns a 'Constraint'. Examples of capabilities includ: @HasReader "foo"
 -- Int@, @MonadIO@, …
-type Capability = (* -> *) -> Constraint
+type Capability = (Type -> Type) -> Constraint
 
 -- | Type family used used to express a conjunction of constraints over a single
 -- type.

--- a/src/Capability/Error.hs
+++ b/src/Capability/Error.hs
@@ -110,7 +110,7 @@ class Monad m
 
 -- | Throw an exception in the specified exception capability.
 throw :: forall tag e m a. HasThrow tag e m => e -> m a
-throw = throw_ (proxy# @_ @tag)
+throw = throw_ (proxy# @tag)
 {-# INLINE throw #-}
 
 -- | Capability to catch exceptions of type @e@ under @tag@.
@@ -144,14 +144,14 @@ class HasThrow tag e m
 -- | Provide a handler for exceptions thrown in the given action
 -- in the given exception capability.
 catch :: forall tag e m a. HasCatch tag e m => m a -> (e -> m a) -> m a
-catch = catch_ (proxy# @_ @tag)
+catch = catch_ (proxy# @tag)
 {-# INLINE catch #-}
 
 -- | Like 'catch', but only handle the exception if the provided function
 -- returns 'Just'.
 catchJust :: forall tag e m a b. HasCatch tag e m
   => (e -> Maybe b) -> m a -> (b -> m a) -> m a
-catchJust = catchJust_ (proxy# @_ @tag)
+catchJust = catchJust_ (proxy# @tag)
 {-# INLINE catchJust #-}
 
 -- | Wrap exceptions @inner@ originating from the given action according to

--- a/src/Capability/Error.hs
+++ b/src/Capability/Error.hs
@@ -91,6 +91,7 @@ import Control.Monad.Trans.Class (MonadTrans, lift)
 import Control.Monad.Trans.Control (MonadTransControl(..))
 import Data.Coerce (Coercible, coerce)
 import qualified Data.Generics.Sum.Constructors as Generic
+import Data.Kind (Type)
 import Data.Typeable (Typeable)
 import GHC.Exts (Proxy#, proxy#)
 import qualified UnliftIO.Exception as UnliftIO
@@ -100,7 +101,7 @@ import qualified UnliftIO.Exception as UnliftIO
 -- @HasThrow@/@HasCatch@ capabilities at different tags should be independent.
 -- See 'HasCatch'.
 class Monad m
-  => HasThrow (tag :: k) (e :: *) (m :: * -> *) | tag m -> e
+  => HasThrow (tag :: k) (e :: Type) (m :: Type -> Type) | tag m -> e
   where
     -- | For technical reasons, this method needs an extra proxy argument.
     -- You only need it if you are defining new instances of 'HasReader'.
@@ -128,7 +129,7 @@ throw = throw_ (proxy# @tag)
 --
 -- See 'wrapError' for a way to combine multiple exception types into one.
 class HasThrow tag e m
-  => HasCatch (tag :: k) (e :: *) (m :: * -> *) | tag m -> e
+  => HasCatch (tag :: k) (e :: Type) (m :: Type -> Type) | tag m -> e
   where
     -- | For technical reasons, this method needs an extra proxy argument.
     -- You only need it if you are defining new instances of 'HasReader'.
@@ -181,7 +182,7 @@ wrapError =
 --   What would the meaning of the tag be?
 
 -- | Derive 'HasError from @m@'s 'Control.Monad.Except.MonadError' instance.
-newtype MonadError m (a :: *) = MonadError (m a)
+newtype MonadError m (a :: Type) = MonadError (m a)
   deriving (Functor, Applicative, Monad, MonadIO, PrimMonad)
 
 instance Except.MonadError e m => HasThrow tag e (MonadError m) where
@@ -204,7 +205,7 @@ instance Except.MonadError e m => HasCatch tag e (MonadError m) where
   {-# INLINE catchJust_ #-}
 
 -- | Derive 'HasThrow' from @m@'s 'Control.Monad.Catch.MonadThrow' instance.
-newtype MonadThrow (e :: *) m (a :: *) = MonadThrow (m a)
+newtype MonadThrow (e :: Type) m (a :: Type) = MonadThrow (m a)
   deriving (Functor, Applicative, Monad, MonadIO, PrimMonad)
 
 instance (Catch.Exception e, Catch.MonadThrow m)
@@ -215,7 +216,7 @@ instance (Catch.Exception e, Catch.MonadThrow m)
     {-# INLINE throw_ #-}
 
 -- | Derive 'HasCatch from @m@'s 'Control.Monad.Catch.MonadCatch instance.
-newtype MonadCatch (e :: *) m (a :: *) = MonadCatch (m a)
+newtype MonadCatch (e :: Type) m (a :: Type) = MonadCatch (m a)
   deriving (Functor, Applicative, Monad, MonadIO, PrimMonad)
   deriving (HasThrow tag e) via MonadThrow e m
 
@@ -242,7 +243,7 @@ instance (Catch.Exception e, Catch.MonadCatch m)
 
 -- | Derive 'HasError' using the functionality from the @safe-exceptions@
 -- package.
-newtype SafeExceptions (e :: *) m (a :: *) = SafeExceptions (m a)
+newtype SafeExceptions (e :: Type) m (a :: Type) = SafeExceptions (m a)
   deriving (Functor, Applicative, Monad, MonadIO, PrimMonad)
 
 instance (Safe.Exception e, Safe.MonadThrow m)
@@ -273,7 +274,7 @@ instance (Safe.Exception e, Safe.MonadCatch m)
     {-# INLINE catchJust_ #-}
 
 -- | Derive 'HasError' using the functionality from the @unliftio@ package.
-newtype MonadUnliftIO (e :: *) m (a :: *) = MonadUnliftIO (m a)
+newtype MonadUnliftIO (e :: Type) m (a :: Type) = MonadUnliftIO (m a)
   deriving (Functor, Applicative, Monad, MonadIO, PrimMonad)
 
 instance (UnliftIO.Exception e, MonadIO m)
@@ -420,7 +421,7 @@ instance
 
 
 -- | Compose two accessors.
-deriving via ((t2 :: (* -> *) -> * -> *) ((t1 :: (* -> *) -> * -> *) m))
+deriving via ((t2 :: (Type -> Type) -> Type -> Type) ((t1 :: (Type -> Type) -> Type -> Type) m))
   instance
   ( forall x. Coercible (m x) (t2 (t1 m) x)
   , Monad m, HasThrow tag e (t2 (t1 m)) )
@@ -428,7 +429,7 @@ deriving via ((t2 :: (* -> *) -> * -> *) ((t1 :: (* -> *) -> * -> *) m))
 
 
 -- | Compose two accessors.
-deriving via ((t2 :: (* -> *) -> * -> *) ((t1 :: (* -> *) -> * -> *) m))
+deriving via ((t2 :: (Type -> Type) -> Type -> Type) ((t1 :: (Type -> Type) -> Type -> Type) m))
   instance
   ( forall x. Coercible (m x) (t2 (t1 m) x)
   , Monad m, HasCatch tag e (t2 (t1 m)) )

--- a/src/Capability/Reader/Internal/Class.hs
+++ b/src/Capability/Reader/Internal/Class.hs
@@ -31,6 +31,7 @@ import Capability.Derive (derive)
 import Capability.Reflection
 import Capability.Source.Internal.Class
 import Data.Coerce (Coercible, coerce)
+import Data.Kind (Type)
 import GHC.Exts (Proxy#, proxy#)
 
 -- | Reader capability
@@ -47,7 +48,7 @@ import GHC.Exts (Proxy#, proxy#)
 -- prop> local @t f (m >>= \x -> k x) = local @t f m >>= \x -> local @t f (k x)
 -- prop> reader @t f = f <$> ask @t
 class (Monad m, HasSource tag r m)
-  => HasReader (tag :: k) (r :: *) (m :: * -> *) | tag m -> r
+  => HasReader (tag :: k) (r :: Type) (m :: Type -> Type) | tag m -> r
   where
     -- | For technical reasons, this method needs an extra proxy argument.
     -- You only need it if you are defining new instances of 'HasReader'.

--- a/src/Capability/Reader/Internal/Class.hs
+++ b/src/Capability/Reader/Internal/Class.hs
@@ -80,7 +80,7 @@ asks = awaits @tag
 -- where @e@ is the environment of the reader capability @tag@.
 -- Symbolically: @return e = ask \@tag@.
 local :: forall tag r m a. HasReader tag r m => (r -> r) -> m a -> m a
-local = local_ (proxy# @_ @tag)
+local = local_ (proxy# @tag)
 {-# INLINE local #-}
 
 -- | @reader \@tag act@
@@ -89,7 +89,7 @@ local = local_ (proxy# @_ @tag)
 --
 -- It happens to coincide with @asks@: @reader = asks@.
 reader :: forall tag r m a. HasReader tag r m => (r -> a) -> m a
-reader = reader_ (proxy# @_ @tag)
+reader = reader_ (proxy# @tag)
 {-# INLINE reader #-}
 
 -- | Execute the given reader action on a sub-component of the current context

--- a/src/Capability/Reader/Internal/Strategies.hs
+++ b/src/Capability/Reader/Internal/Strategies.hs
@@ -40,6 +40,7 @@ import Control.Monad.Trans.Control (MonadTransControl(..))
 import Data.Coerce (Coercible, coerce)
 import qualified Data.Generics.Product.Fields as Generic
 import qualified Data.Generics.Product.Positions as Generic
+import Data.Kind (Type)
 import GHC.Exts (Proxy#)
 
 instance Reader.MonadReader r m => HasReader tag r (MonadReader m) where
@@ -167,7 +168,7 @@ instance (HasReader tag r m, MonadTransControl t, Monad (t m))
     {-# INLINE reader_ #-}
 
 -- | Compose two accessors.
-deriving via ((t2 :: (* -> *) -> * -> *) ((t1 :: (* -> *) -> * -> *) m))
+deriving via ((t2 :: (Type -> Type) -> Type -> Type) ((t1 :: (Type -> Type) -> Type -> Type) m))
   instance
   ( forall x. Coercible (m x) (t2 (t1 m) x)
   , Monad m, HasReader tag r (t2 (t1 m)) )

--- a/src/Capability/Reflection.hs
+++ b/src/Capability/Reflection.hs
@@ -46,6 +46,7 @@ module Capability.Reflection
 
 import Capability.Constraints
 import Capability.Derive
+import Data.Kind (Type)
 import Data.Proxy
 import Data.Reflection
 
@@ -131,7 +132,7 @@ interpret dict action =
 --         _state :: forall a. (s -> (a, s)) -> m a
 --       }
 --   :}
-data family Reified (tag :: k) (c :: Capability) (m :: * -> *)
+data family Reified (tag :: k) (c :: Capability) (m :: Type -> Type)
 
 -- | @Reflected s capability m@
 --
@@ -158,7 +159,7 @@ data family Reified (tag :: k) (c :: Capability) (m :: * -> *)
 --     where
 --     yield a = Reflect $ _yield (reified @s) a
 --   :}
-newtype Reflected (s :: *) (c :: Capability) (m :: * -> *) (a :: *) = Reflect (m a)
+newtype Reflected (s :: Type) (c :: Capability) (m :: Type -> Type) (a :: Type) = Reflect (m a)
   deriving (Functor, Applicative, Monad)
 
 -- | @reified \@s@

--- a/src/Capability/Reflection.hs
+++ b/src/Capability/Reflection.hs
@@ -11,6 +11,7 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 -- | Use this module to provide an ad-hoc interpreter for a capability using
 -- type class reflection.

--- a/src/Capability/Sink/Internal/Class.hs
+++ b/src/Capability/Sink/Internal/Class.hs
@@ -24,6 +24,7 @@ module Capability.Sink.Internal.Class where
 
 import Capability.Reflection
 import Data.Coerce (coerce)
+import Data.Kind (Type)
 import GHC.Exts (Proxy#, proxy#)
 
 -- | Sinking capability.
@@ -31,7 +32,7 @@ import GHC.Exts (Proxy#, proxy#)
 -- An instance does not need to fulfill any additional laws
 -- besides the monad laws.
 class Monad m
-  => HasSink (tag :: k) (a :: *) (m :: * -> *) | tag m -> a
+  => HasSink (tag :: k) (a :: Type) (m :: Type -> Type) | tag m -> a
   where
     -- | For technical reasons, this method needs an extra proxy argument.
     -- You only need it if you are defining new instances of 'HasSink'.

--- a/src/Capability/Sink/Internal/Class.hs
+++ b/src/Capability/Sink/Internal/Class.hs
@@ -42,7 +42,7 @@ class Monad m
 -- | @yield \@tag a@
 -- emits @a@ in the sink capability @tag@.
 yield :: forall tag a m. HasSink tag a m => a -> m ()
-yield = yield_ (proxy# @_ @tag)
+yield = yield_ (proxy# @tag)
 {-# INLINE yield #-}
 
 --------------------------------------------------------------------------------

--- a/src/Capability/Sink/Internal/Strategies.hs
+++ b/src/Capability/Sink/Internal/Strategies.hs
@@ -34,10 +34,7 @@ import Capability.Sink.Internal.Class
 import Capability.State.Internal.Class
 import Capability.State.Internal.Strategies.Common
 import Control.Lens (set)
-import Control.Monad.IO.Class (MonadIO)
-import Control.Monad.Primitive (PrimMonad)
 import qualified Control.Monad.State.Class as State
-import Control.Monad.Trans.Class (MonadTrans, lift)
 import Data.Coerce (Coercible, coerce)
 import Data.DList (DList)
 import qualified Data.DList as DList

--- a/src/Capability/Source/Internal/Class.hs
+++ b/src/Capability/Source/Internal/Class.hs
@@ -56,7 +56,7 @@ class Monad m
 -- | @await \@tag a@
 -- takes @a@ from the source capability @tag@.
 await :: forall tag a m. HasSource tag a m => m a
-await = await_ (proxy# @_ @tag)
+await = await_ (proxy# @tag)
 {-# INLINE await #-}
 
 -- | @awaits \@tag@

--- a/src/Capability/Source/Internal/Class.hs
+++ b/src/Capability/Source/Internal/Class.hs
@@ -38,6 +38,7 @@ module Capability.Source.Internal.Class where
 
 import Capability.Reflection
 import Data.Coerce (coerce)
+import Data.Kind (Type)
 import GHC.Exts (Proxy#, proxy#)
 
 -- | Sourcing capability.
@@ -45,7 +46,7 @@ import GHC.Exts (Proxy#, proxy#)
 -- An instance does not need to fulfill any additional laws
 -- besides the monad laws.
 class Monad m
-  => HasSource (tag :: k) (a :: *) (m :: * -> *) | tag m -> a
+  => HasSource (tag :: k) (a :: Type) (m :: Type -> Type) | tag m -> a
   where
     -- | For technical reasons, this method needs an extra proxy argument.
     -- You only need it if you are defining new instances of 'HasSource'.

--- a/src/Capability/Source/Internal/Strategies.hs
+++ b/src/Capability/Source/Internal/Strategies.hs
@@ -44,6 +44,7 @@ import qualified Control.Monad.State.Class as State
 import Control.Monad.Trans.Class (MonadTrans, lift)
 import Data.Coerce (Coercible, coerce)
 import Data.IORef
+import Data.Kind (Type)
 import Data.Mutable
 import qualified Data.Generics.Product.Fields as Generic
 import qualified Data.Generics.Product.Positions as Generic
@@ -52,7 +53,7 @@ import qualified Data.Generics.Product.Positions as Generic
 
 -- | Derive 'HasSource' from @m@'s 'Control.Monad.Reader.Class.MonadReader'
 -- instance.
-newtype MonadReader (m :: * -> *) (a :: *) = MonadReader (m a)
+newtype MonadReader (m :: Type -> Type) (a :: Type) = MonadReader (m a)
   deriving (Functor, Applicative, Monad, MonadIO, PrimMonad)
 
 instance Reader.MonadReader r m => HasSource tag r (MonadReader m) where
@@ -74,7 +75,7 @@ instance Reader.MonadReader r m => HasSource tag r (MonadReader m) where
 -- exceptions.
 --
 -- See 'ReadState'.
-newtype ReadStatePure (m :: * -> *) (a :: *) = ReadStatePure (m a)
+newtype ReadStatePure (m :: Type -> Type) (a :: Type) = ReadStatePure (m a)
   deriving (Functor, Applicative, Monad)
 
 instance HasState tag r m => HasSource tag r (ReadStatePure m) where
@@ -86,7 +87,7 @@ instance HasState tag r m => HasSource tag r (ReadStatePure m) where
 -- Use this if the monad stack allows catching exceptions.
 --
 -- See 'ReadStatePure'.
-newtype ReadState (m :: * -> *) (a :: *) = ReadState (m a)
+newtype ReadState (m :: Type -> Type) (a :: Type) = ReadState (m a)
   deriving (Functor, Applicative, Monad, MonadIO, PrimMonad)
 
 instance
@@ -104,7 +105,7 @@ instance
       awaits @oldtag $ view (Generic.position' @pos)
     {-# INLINE await_ #-}
 
-deriving via ((t2 :: (* -> *) -> * -> *) ((t1 :: (* -> *) -> * -> *) m))
+deriving via ((t2 :: (Type -> Type) -> Type -> Type) ((t1 :: (Type -> Type) -> Type -> Type) m))
   instance
   ( forall x. Coercible (m x) (t2 (t1 m) x)
   , Monad m, HasSource tag r (t2 (t1 m)) )

--- a/src/Capability/Source/Internal/Strategies.hs
+++ b/src/Capability/Source/Internal/Strategies.hs
@@ -38,7 +38,6 @@ import Capability.Accessors
 import Control.Lens (view)
 import Control.Monad.Catch (MonadMask)
 import Control.Monad.IO.Class (MonadIO, liftIO)
-import Control.Monad.Primitive (PrimMonad)
 import qualified Control.Monad.Reader.Class as Reader
 import qualified Control.Monad.State.Class as State
 import Control.Monad.Trans.Class (MonadTrans, lift)

--- a/src/Capability/State/Internal/Class.hs
+++ b/src/Capability/State/Internal/Class.hs
@@ -75,7 +75,7 @@ put = yield @tag
 -- Given the current state @s@ of the state capability @tag@
 -- and @(a, s') = f s@, update the state to @s'@ and return @a@.
 state :: forall tag s m a. HasState tag s m => (s -> (a, s)) -> m a
-state = state_ (proxy# @_ @tag)
+state = state_ (proxy# @tag)
 {-# INLINE state #-}
 
 -- | @modify \@tag f@

--- a/src/Capability/State/Internal/Class.hs
+++ b/src/Capability/State/Internal/Class.hs
@@ -34,6 +34,7 @@ import Capability.Reflection
 import Capability.Source.Internal.Class
 import Capability.Sink.Internal.Class
 import Data.Coerce (Coercible, coerce)
+import Data.Kind (Type)
 import GHC.Exts (Proxy#, proxy#)
 
 -- | State capability
@@ -48,7 +49,7 @@ import GHC.Exts (Proxy#, proxy#)
 -- prop> put @t s >> get @t = put @t s >> pure s
 -- prop> state @t f = get @t >>= \s -> let (a, s') = f s in put @t s' >> pure a
 class (Monad m, HasSource tag s m, HasSink tag s m)
-  => HasState (tag :: k) (s :: *) (m :: * -> *) | tag m -> s
+  => HasState (tag :: k) (s :: Type) (m :: Type -> Type) | tag m -> s
   where
     -- | For technical reasons, this method needs an extra proxy argument.
     -- You only need it if you are defining new instances of 'HasState.

--- a/src/Capability/State/Internal/Strategies.hs
+++ b/src/Capability/State/Internal/Strategies.hs
@@ -41,6 +41,7 @@ import Data.Coerce (Coercible, coerce)
 import qualified Data.Generics.Product.Fields as Generic
 import qualified Data.Generics.Product.Positions as Generic
 import Data.IORef
+import Data.Kind (Type)
 import Data.Mutable
 import GHC.Exts (Proxy#)
 
@@ -106,7 +107,7 @@ instance (HasState tag s m, MonadTrans t, Monad (t m))
     {-# INLINE state_ #-}
 
 -- | Compose two accessors.
-deriving via ((t2 :: (* -> *) -> * -> *) ((t1 :: (* -> *) -> * -> *) m))
+deriving via ((t2 :: (Type -> Type) -> Type -> Type) ((t1 :: (Type -> Type) -> Type -> Type) m))
   instance
   ( forall x. Coercible (m x) (t2 (t1 m) x)
   , Monad m, HasState tag s (t2 (t1 m)) )

--- a/src/Capability/State/Internal/Strategies.hs
+++ b/src/Capability/State/Internal/Strategies.hs
@@ -34,7 +34,6 @@ import Capability.State.Internal.Strategies.Common
 import Capability.Source.Internal.Strategies ()
 import Capability.Sink.Internal.Strategies ()
 import Control.Monad.IO.Class (MonadIO, liftIO)
-import Control.Monad.Primitive (PrimMonad)
 import qualified Control.Monad.State.Class as State
 import Control.Monad.Trans.Class (MonadTrans, lift)
 import Data.Coerce (Coercible, coerce)

--- a/src/Capability/State/Internal/Strategies/Common.hs
+++ b/src/Capability/State/Internal/Strategies/Common.hs
@@ -31,10 +31,11 @@ module Capability.State.Internal.Strategies.Common
 
 import Control.Monad.IO.Class (MonadIO)
 import Control.Monad.Primitive (PrimMonad)
+import Data.Kind (Type)
 
 -- | Derive 'HasState' from @m@'s
 -- 'Control.Monad.State.Class.MonadState' instance.
-newtype MonadState (m :: * -> *) (a :: *) = MonadState (m a)
+newtype MonadState (m :: Type -> Type) (a :: Type) = MonadState (m a)
   deriving (Functor, Applicative, Monad, MonadIO, PrimMonad)
 
 -- | Derive a state monad from a reader over an 'Data.IORef.IORef'.
@@ -66,5 +67,5 @@ newtype ReaderIORef m a = ReaderIORef (m a)
 -- >   => HasState "foo" Int (MyState m)
 --
 -- See 'ReaderIORef' for a specialized version over 'Data.IORef.IORef'.
-newtype ReaderRef m (a :: *) = ReaderRef (m a)
+newtype ReaderRef m (a :: Type) = ReaderRef (m a)
   deriving (Functor, Applicative, Monad, MonadIO, PrimMonad)

--- a/src/Capability/TypeOf.hs
+++ b/src/Capability/TypeOf.hs
@@ -4,12 +4,14 @@
 
 module Capability.TypeOf where
 
+import Data.Kind (Type)
+
 -- | Type family associating a tag to the corresponding type. It is intended to
 -- simplify constraint declarations, by removing the need to redundantly specify
 -- the type associated to a tag.
 --
 -- It is poly-kinded, which allows users to define their own kind of tags.
--- Standard haskell types can also be used as tags by specifying the '*' kind
+-- Standard haskell types can also be used as tags by specifying the 'Type' kind
 -- when defining the type family instance.
 --
 -- Defining 'TypeOf' instances for 'GHC.TypeLits.Symbol's (typelevel string
@@ -26,11 +28,11 @@ module Capability.TypeOf where
 --
 --     data Foo
 --     data Bar
---     type instance TypeOf * Foo = Int
---     type instance TypeOf * Bar = String
+--     type instance TypeOf Type Foo = Int
+--     type instance TypeOf Type Bar = String
 --
 --     -- Same as: foo :: HasReader Foo Int M => …
 --     foo :: HasReader' Foo m => …
 --     foo = …
 -- @
-type family TypeOf k (s :: k) :: *
+type family TypeOf k (s :: k) :: Type

--- a/src/Capability/Writer.hs
+++ b/src/Capability/Writer.hs
@@ -121,13 +121,13 @@ class (Monoid w, Monad m, HasSink tag w m)
 -- Appends @w@ to the output of the writer capability @tag@
 -- and returns the value @a@.
 writer :: forall tag w m a. HasWriter tag w m => (a, w) -> m a
-writer = writer_ (proxy# @_ @tag)
+writer = writer_ (proxy# @tag)
 {-# INLINE writer #-}
 
 -- | @tell \@tag w@
 -- appends @w@ to the output of the writer capability @tag@.
 tell :: forall tag w m. HasWriter tag w m => w -> m ()
-tell = yield_ (proxy# @_ @tag)
+tell = yield_ (proxy# @tag)
 {-# INLINE tell #-}
 
 -- | @listen \@tag m@
@@ -135,7 +135,7 @@ tell = yield_ (proxy# @_ @tag)
 -- in the writer capability @tag@ along with result of @m@.
 -- Appends the output of @m@ to the output of the writer capability @tag@.
 listen :: forall tag w m a. HasWriter tag w m => m a -> m (a, w)
-listen = listen_ (proxy# @_ @tag)
+listen = listen_ (proxy# @tag)
 {-# INLINE listen #-}
 
 -- | @pass \@tag m@
@@ -143,7 +143,7 @@ listen = listen_ (proxy# @_ @tag)
 -- @w@ to the output of the writer capability @tag@.
 -- @pass \@tag m@ instead appends @w' = f w@ to the output and returns @a@.
 pass :: forall tag w m a. HasWriter tag w m => m (a, w -> w) -> m a
-pass = pass_ (proxy# @_ @tag)
+pass = pass_ (proxy# @tag)
 {-# INLINE pass #-}
 
 -- | Compose two accessors.

--- a/src/Capability/Writer.hs
+++ b/src/Capability/Writer.hs
@@ -67,6 +67,7 @@ import Capability.State
 -- import deprecated module to reexport deprecated item for back-compat.
 import Capability.Stream
 import Data.Coerce (Coercible, coerce)
+import Data.Kind (Type)
 import GHC.Exts (Proxy#, proxy#)
 
 -- | Writer capability
@@ -96,7 +97,7 @@ import GHC.Exts (Proxy#, proxy#)
 -- regardless of whatever additional methods it provides and laws by which it
 -- abides.
 class (Monoid w, Monad m, HasSink tag w m)
-  => HasWriter (tag :: k) (w :: *) (m :: * -> *) | tag m -> w
+  => HasWriter (tag :: k) (w :: Type) (m :: Type -> Type) | tag m -> w
   where
     -- | For technical reasons, this method needs an extra proxy argument.
     -- You only need it if you are defining new instances of 'HasReader'.
@@ -147,7 +148,7 @@ pass = pass_ (proxy# @tag)
 {-# INLINE pass #-}
 
 -- | Compose two accessors.
-deriving via ((t2 :: (* -> *) -> * -> *) ((t1 :: (* -> *) -> * -> *) m))
+deriving via ((t2 :: (Type -> Type) -> Type -> Type) ((t1 :: (Type -> Type) -> Type -> Type) m))
   instance
   ( forall x. Coercible (m x) (t2 (t1 m) x)
   , Monad m, HasWriter tag w (t2 (t1 m)) )


### PR DESCRIPTION
Visibility of the kind argument changed in
https://gitlab.haskell.org/ghc/ghc/-/commit/012257c15f584069500af2953ab70856f9a1470e
.

This makes capability compatible with GHC 8.10 .

We still need to change the dependencies to be recent enough.