### PR TITLE
Release 0.4.0.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## 0.4.0.0 -- 2021-03-15
 
-* Fix infite loop in `writer`.
+* Fix infinite loop in `writer`.
   See [#85](https://github.com/tweag/capability/pull/85)
 
 * Introduce `Capability.Reflection` to define ad-hoc interpreters.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,16 @@
 # Revision history for capability
 
+## 0.4.0.0 -- 2021-03-15
+
+* Fix infite loop in `writer`.
+  See [#85](https://github.com/tweag/capability/pull/85)
+
+* Introduce `Capability.Reflection` to define ad-hoc interpreters.
+  See [#86](https://github.com/tweag/capability/pull/86)
+
+* Fix compatibility with GHC 8.10.
+  See [#87](https://github.com/tweag/capability/pull/87)
+
 ## 0.3.0.0 -- 2020-03-19
 
 * Rename HasStream to HasSink, for symmetry.

--- a/capability.cabal
+++ b/capability.cabal
@@ -1,5 +1,5 @@
 name: capability
-version: 0.3.0.0
+version: 0.4.0.0
 homepage: https://github.com/tweag/capability
 license: BSD3
 license-file: LICENSE.md

--- a/capability.cabal
+++ b/capability.cabal
@@ -12,7 +12,7 @@ extra-source-files:
   CONTRIBUTING.md
   README.md
 cabal-version: 1.18
-tested-with: GHC==8.6.1
+tested-with: GHC==8.10.4
 synopsis: Extensional capabilities and deriving combinators
 description:
   Standard capability type classes for extensional effects and combinators


### PR DESCRIPTION
- Bump version number
- Update changelog

See package candidate: https://hackage.haskell.org/package/capability-0.4.0.0/candidate