### PR TITLE
Add `censor` function to Capability.Writer

### DIFF
--- a/examples/Writer.hs
+++ b/examples/Writer.hs
@@ -21,7 +21,7 @@ import Test.Hspec
 
 -- | Increase a counter using a writer monad.
 useWriter :: HasWriter "count-writer" (Sum Int) m => m ()
-useWriter = do
+useWriter = censor @"count-writer" (*2) {- double the eventual result -} $ do
   -- Add 3 and retrieve result
   ((), count) <- listen @"count-writer" (tell @"count-writer" 3)
   -- Duplicate
@@ -82,9 +82,9 @@ spec :: Spec
 spec = do
   describe "WriterM" $
     it "evaluates useWriter" $
-      runWriterM useWriter `shouldBe` ((), 6)
+      runWriterM useWriter `shouldBe` ((), 12)
   describe "BadWriterM" $ do
     it "evaluates useWriter" $
-      runBadWriterM useWriter `shouldBe` ((), 6)
+      runBadWriterM useWriter `shouldBe` ((), 12)
     it "evaluates mixWriterState" $
       runBadWriterM mixWriterState `shouldBe` (1, 2)

--- a/src/Capability/Writer.hs
+++ b/src/Capability/Writer.hs
@@ -31,6 +31,7 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeInType #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -47,6 +48,7 @@ module Capability.Writer
   , tell
   , listen
   , pass
+  , censor
   -- * Functional capability
   , HasWriter'
   , TypeOf
@@ -146,6 +148,17 @@ listen = listen_ (proxy# @tag)
 pass :: forall tag w m a. HasWriter tag w m => m (a, w -> w) -> m a
 pass = pass_ (proxy# @tag)
 {-# INLINE pass #-}
+
+censor_ :: forall k (tag :: k) w m a. HasWriter tag w m => Proxy# tag -> (w -> w) -> m a -> m a
+censor_ tag f m = pass_ tag $ (,f) <$> m
+
+-- | @censor \@tag f m@
+--   is an action that executes the action @m@ and applies the
+--   function @f@ to the output of the writer capability @tag@,
+--   leaving the return value unchanged.
+censor :: forall tag w m a. HasWriter tag w m => (w -> w) -> m a -> m a
+censor = censor_ (proxy# @tag)
+{-# INLINE censor #-}
 
 -- | Compose two accessors.
 deriving via ((t2 :: (Type -> Type) -> Type -> Type) ((t1 :: (Type -> Type) -> Type -> Type) m))


### PR DESCRIPTION
This is a useful function, present in the corresponding mtl library,
that can be defined in terms of the existing `pass` primitive.
However, doing so is nontrivial (I spent quite a while banging my head
against proxies, ScopedTypeVariables, AllowAmbiguousTypes, and the
like) so it seems it would make sense to provide it directly
from the library.  However, if there's some reason this function can't
or shouldn't be provided I'd be happy to be enlightened.