### PR TITLE
Release 0.5.0.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,19 @@
 # Revision history for capability
 
+## 0.5.0.0 -- 2021-07-21
+
+* Fix compatibility with GHC 9.0.
+  See [#96](https://github.com/tweag/capability/pull/96)
+
+* Remove `Capability.Writer.Discouraged`.
+  This module incurred a dependency on monad-unlift which is no longer
+  available for GHC 9.0. Given that its use was discouraged, it was deemed best
+  to remove it.
+  See [#96](https://github.com/tweag/capability/pull/96)
+
+* Added `censor` function to `Capability.Writer`.
+  See [#94](https://github.com/tweag/capability/pull/94)
+
 ## 0.4.0.0 -- 2021-03-15
 
 * Fix infinite loop in `writer`.

--- a/capability.cabal
+++ b/capability.cabal
@@ -12,7 +12,7 @@ extra-source-files:
   CONTRIBUTING.md
   README.md
 cabal-version: 1.18
-tested-with: GHC==8.10.4
+tested-with: GHC==8.10.4, GHC==9.0.1
 synopsis: Extensional capabilities and deriving combinators
 description:
   Standard capability type classes for extensional effects and combinators

--- a/capability.cabal
+++ b/capability.cabal
@@ -1,5 +1,5 @@
 name: capability
-version: 0.4.0.0
+version: 0.5.0.0
 homepage: https://github.com/tweag/capability
 license: BSD3
 license-file: LICENSE.md

--- a/capability.cabal
+++ b/capability.cabal
@@ -63,7 +63,7 @@ library
     , constraints >= 0.1 && < 0.14
     , dlist >= 0.8 && < 1.1
     , exceptions >= 0.6 && < 0.11
-    , generic-lens >= 2.0 && < 2.2
+    , generic-lens >= 2.0 && < 2.3
     , lens >= 4.16 && < 5.1
     , monad-control >= 1.0 && < 1.1
     , mtl >= 2.0 && < 3.0
@@ -72,7 +72,7 @@ library
     , reflection >= 2.1 && < 2.2
     , safe-exceptions >= 0.1 && < 0.2
     , streaming >= 0.2 && < 0.3
-    , transformers >= 0.5.5 && < 0.6
+    , transformers >= 0.5.5 && < 0.7
     , unliftio >= 0.2 && < 0.3
     , unliftio-core >= 0.1 && < 0.3
   if flag(dev)

--- a/stack-ghc9.yaml
+++ b/stack-ghc9.yaml
@@ -4,9 +4,5 @@ packages:
 - .
 
 extra-deps:
-# Generic-lens is not yet released in a 9.0-compatible version
-- git: https://github.com/kcsongor/generic-lens.git
-  commit: 8e1fc7dcf444332c474fca17110d4bc554db08c8
-  subdirs:
-  - generic-lens-core
-  - generic-lens
+- generic-lens-core-2.2.0.0
+- generic-lens-2.2.0.0

--- a/stack-ghc9.yaml.lock
+++ b/stack-ghc9.yaml.lock
@@ -5,31 +5,19 @@
 
 packages:
 - completed:
-    subdir: generic-lens-core
-    name: generic-lens-core
-    version: 2.1.0.0
-    git: https://github.com/kcsongor/generic-lens.git
+    hackage: generic-lens-core-2.2.0.0@sha256:b6b69e992f15fa80001de737f41f2123059011a1163d6c8941ce2e3ab44f8c03,2913
     pantry-tree:
-      size: 2283
-      sha256: 5a26b16c38ad8d8ebc81182e1d09858858f16dc117a0c7b084d8446d3a17d749
-    commit: 8e1fc7dcf444332c474fca17110d4bc554db08c8
+      size: 2202
+      sha256: 6918fb47f34ecf4246778b229911693b6e20fc2ce94ae8c89d69a89db4e72269
   original:
-    subdir: generic-lens-core
-    git: https://github.com/kcsongor/generic-lens.git
-    commit: 8e1fc7dcf444332c474fca17110d4bc554db08c8
+    hackage: generic-lens-core-2.2.0.0
 - completed:
-    subdir: generic-lens
-    name: generic-lens
-    version: 2.1.0.0
-    git: https://github.com/kcsongor/generic-lens.git
+    hackage: generic-lens-2.2.0.0@sha256:4008a39f464e377130346e46062e2ac1211f9d2e256bbb1857216e889c7196be,3867
     pantry-tree:
-      size: 2630
-      sha256: aba81557550537d4cfda2c1b07accff8589da44a1e418a3cde5639eb438d1c86
-    commit: 8e1fc7dcf444332c474fca17110d4bc554db08c8
+      size: 2470
+      sha256: 93d7aae1de4cbbb2e3320b357cd744618cb17356989bd417d374aa73331e7370
   original:
-    subdir: generic-lens
-    git: https://github.com/kcsongor/generic-lens.git
-    commit: 8e1fc7dcf444332c474fca17110d4bc554db08c8
+    hackage: generic-lens-2.2.0.0
 snapshots:
 - completed:
     size: 540164


### PR DESCRIPTION
* Bump dependency version numbers
  A GHC 9.0 compatible version of generic-lens has been released meanwhile
* Update the tested-with section to include GHC 9.0.1
* Update Changelog
* Bump version number to 0.5.0.0
  I've decided on a major version update since the removal of `Capability.Writer.Discouraged` can be viewed as a breaking change.

The package candidate on Hackage can be found here: https://hackage.haskell.org/package/capability-0.5.0.0/candidate