### PR TITLE
Release 0.5.0.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
       run: $NIXSHELL --run "cabal haddock"
 
   stack-ghc9:
-    name: Build on GHC 9.0
+    name: Build on GHC 9.2
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2.3.4

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,10 @@
 # Revision history for capability
 
+## 0.5.0.1 -- 2022-03-21
+
+* Fix compatibility with GHC 9.2.
+  See [Ghc 9.2.x migration guide](https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.2#undecidableinstances-no-longer-implies-flexiblecontexts-in-instance-declarations).
+
 ## 0.5.0.0 -- 2021-07-21
 
 * Fix compatibility with GHC 9.0.

--- a/capability.cabal
+++ b/capability.cabal
@@ -1,5 +1,5 @@
 name: capability
-version: 0.5.0.0
+version: 0.5.0.1
 homepage: https://github.com/tweag/capability
 license: BSD3
 license-file: LICENSE.md

--- a/capability.cabal
+++ b/capability.cabal
@@ -64,7 +64,7 @@ library
     , dlist >= 0.8 && < 1.1
     , exceptions >= 0.6 && < 0.11
     , generic-lens >= 2.0 && < 2.3
-    , lens >= 4.16 && < 5.1
+    , lens >= 4.16 && < 5.2
     , monad-control >= 1.0 && < 1.1
     , mtl >= 2.0 && < 3.0
     , mutable-containers >= 0.3 && < 0.4

--- a/src/Capability/Error.hs
+++ b/src/Capability/Error.hs
@@ -26,6 +26,7 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}

--- a/src/Capability/State/Internal/Strategies.hs
+++ b/src/Capability/State/Internal/Strategies.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE InstanceSigs #-}

--- a/src/Capability/Writer.hs
+++ b/src/Capability/Writer.hs
@@ -20,6 +20,7 @@
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}

--- a/stack-ghc9.yaml
+++ b/stack-ghc9.yaml
@@ -1,8 +1,4 @@
-resolver: nightly-2021-07-04
+resolver: nightly-2022-03-20
 
 packages:
 - .
-
-extra-deps:
-- generic-lens-core-2.2.0.0
-- generic-lens-2.2.0.0

--- a/stack-ghc9.yaml.lock
+++ b/stack-ghc9.yaml.lock
@@ -3,24 +3,10 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages:
-- completed:
-    hackage: generic-lens-core-2.2.0.0@sha256:b6b69e992f15fa80001de737f41f2123059011a1163d6c8941ce2e3ab44f8c03,2913
-    pantry-tree:
-      size: 2202
-      sha256: 6918fb47f34ecf4246778b229911693b6e20fc2ce94ae8c89d69a89db4e72269
-  original:
-    hackage: generic-lens-core-2.2.0.0
-- completed:
-    hackage: generic-lens-2.2.0.0@sha256:4008a39f464e377130346e46062e2ac1211f9d2e256bbb1857216e889c7196be,3867
-    pantry-tree:
-      size: 2470
-      sha256: 93d7aae1de4cbbb2e3320b357cd744618cb17356989bd417d374aa73331e7370
-  original:
-    hackage: generic-lens-2.2.0.0
+packages: []
 snapshots:
 - completed:
-    size: 540164
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2021/7/4.yaml
-    sha256: 195e3e9394de03e724525e210f82e30c4488f7c8a09fc70850d75d8b79332993
-  original: nightly-2021-07-04
+    size: 505396
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2022/3/20.yaml
+    sha256: bc9df2f2f2a6bc8814a5f9976de39f8e37eaceee47f887bc72ebb2518e5d3473
+  original: nightly-2022-03-20


### PR DESCRIPTION
* Bump the `lens` dependency version bound. (This was raised [on Stackage nightly](https://github.com/commercialhaskell/stackage/issues/6486#issuecomment-1073120594))
* Fix compatibility issues with GHC 9.2.2, see [Ghc 9.2.x migration guide](https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.2#undecidableinstances-no-longer-implies-flexiblecontexts-in-instance-declarations).
* Update `stack` CI pipeline to test on GHC 9.2.2.
* Update changelog
* Bump version number

The package candidate on Hackage can be found here: https://hackage.haskell.org/package/capability-0.5.0.1/candidate