### PR TITLE
Bump version bound on lens

### DIFF
--- a/capability.cabal
+++ b/capability.cabal
@@ -64,7 +64,7 @@ library
     , dlist >= 0.8 && < 1.1
     , exceptions >= 0.6 && < 0.11
     , generic-lens >= 2.0 && < 2.3
-    , lens >= 4.16 && < 5.2
+    , lens >= 4.16 && < 5.3
     , monad-control >= 1.0 && < 1.1
     , mtl >= 2.0 && < 3.0
     , mutable-containers >= 0.3 && < 0.4


### PR DESCRIPTION
As [pointed out by Stackage](https://github.com/commercialhaskell/stackage/issues/6678) the latest lens 5.2 is out of bounds.
I've tested lens 5.2 with GHC 9.4 with `cabal v2-test` and capability's tests pass without any changes beyond the version bound.
I'll create a new Hackage revision on the latest capability release to incorporate this version bump.
