### PR TITLE
Bump version bound on primitive

### DIFF
--- a/capability.cabal
+++ b/capability.cabal
@@ -12,7 +12,7 @@ extra-source-files:
   CONTRIBUTING.md
   README.md
 cabal-version: 1.18
-tested-with: GHC==8.10.4, GHC==9.0.1
+tested-with: GHC==8.10.4, GHC==9.2.2
 synopsis: Extensional capabilities and deriving combinators
 description:
   Standard capability type classes for extensional effects and combinators

--- a/capability.cabal
+++ b/capability.cabal
@@ -68,7 +68,7 @@ library
     , monad-control >= 1.0 && < 1.1
     , mtl >= 2.0 && < 3.0
     , mutable-containers >= 0.3 && < 0.4
-    , primitive >= 0.6 && < 0.8
+    , primitive >= 0.6 && < 0.9
     , reflection >= 2.1 && < 2.2
     , safe-exceptions >= 0.1 && < 0.2
     , streaming >= 0.2 && < 0.3


### PR DESCRIPTION
Update the version bounds on the `primitive` dependency to address https://github.com/commercialhaskell/stackage/issues/6887.

Tested with GHC 9.2.5 with
```
$ cabal v2-configure --constraint=primitive==0.8.0.0 --allow-newer=primitive
$ cabal v2-build
$ cabal v2-test
```
The `--allow-newer` flag was needed due to a conflict between `primitive` and the version bounds on `vector-algorithms-0.9.0.1`.

I also used this opportunity to update the `tested-with` field to reflect the GHC versions used on CI.

I'll create a new Hackage revision on the latest capability release to incorporate this version bump.
