### PR TITLE
Bump version bounds for constraints and primitive

### DIFF
--- a/capability.cabal
+++ b/capability.cabal
@@ -60,7 +60,7 @@ library
     Capability.Writer
   build-depends:
       base >= 4.14 && < 5.0
-    , constraints >= 0.1 && < 0.14
+    , constraints >= 0.1 && < 0.15
     , dlist >= 0.8 && < 1.1
     , exceptions >= 0.6 && < 0.11
     , generic-lens >= 2.0 && < 2.3
@@ -68,7 +68,7 @@ library
     , monad-control >= 1.0 && < 1.1
     , mtl >= 2.0 && < 3.0
     , mutable-containers >= 0.3 && < 0.4
-    , primitive >= 0.6 && < 0.9
+    , primitive >= 0.6 && < 0.10
     , reflection >= 2.1 && < 2.2
     , safe-exceptions >= 0.1 && < 0.2
     , streaming >= 0.2 && < 0.3


### PR DESCRIPTION
To address https://github.com/commercialhaskell/stackage/issues/7138.

Tested with GHC 9.8.1 with
```
$ cabal v2-configure --constraint=primitive==0.9.0.0
$ cabal v2-build
$ cabal v2-test
```

I'll create a new Hackage revision on the latest capability release to incorporate this version bump.

