### PR TITLE
Bump version bound for lens

### DIFF
--- a/capability.cabal
+++ b/capability.cabal
@@ -64,7 +64,7 @@ library
     , dlist >= 0.8 && < 1.1
     , exceptions >= 0.6 && < 0.11
     , generic-lens >= 2.0 && < 2.3
-    , lens >= 4.16 && < 5.3
+    , lens >= 4.16 && < 5.4
     , monad-control >= 1.0 && < 1.1
     , mtl >= 2.0 && < 3.0
     , mutable-containers >= 0.3 && < 0.4


### PR DESCRIPTION
To address https://github.com/commercialhaskell/stackage/issues/7408

Tested with
```
$ cabal v2-configure --constraint=lens==5.3.2
$ cabal v2-build
$ cabal v2-test
```

I'll create a new Hackage revision as well.
